### PR TITLE
clean up gcc warnings in ascend/ except test_ascEnvVars

### DIFF
--- a/ascend/compiler/relerr.c
+++ b/ascend/compiler/relerr.c
@@ -66,7 +66,7 @@ int rel_errorlist_set_name(rel_errorlist *err, const struct Name *errname){
 	return 0;
 }
 
-int rel_errorlist_get_find_error(rel_errorlist *err){
+enum find_errors rel_errorlist_get_find_error(rel_errorlist *err){
 	assert(err!=NULL);
 	return err->ferr;
 }

--- a/ascend/compiler/relerr.h
+++ b/ascend/compiler/relerr.h
@@ -94,6 +94,12 @@ struct rel_errorlist_struct{
 };
 typedef struct rel_errorlist_struct rel_errorlist;
 
+#if (SIZEOF_VOIDP > SIZE_OF_INT)
+#define enum_to_vp(x) ((void*)(long)x)
+#else
+#define enum_to_vp(x) (x)
+#endif
+
 /* we will try using the 'cleanup' attribute (GCC, clang) for automating the
 freeing of memory for rel_errorlist. In cases where compilers don't support
 something like this, we can simply not provide extended error reporting, 
@@ -119,7 +125,7 @@ int rel_errorlist_set_find_error_name(rel_errorlist *err, enum find_errors ferr,
 
 int rel_errorlist_set_name(rel_errorlist *err, const struct Name *errname);
 
-int rel_errorlist_get_find_error(rel_errorlist *err);
+enum find_errors rel_errorlist_get_find_error(rel_errorlist *err);
 int rel_errorlist_set_find_errpos(rel_errorlist *err,unsigned long errpos);
 //int rel_errorlist_get_lastcode(rel_errorlist *err);
 

--- a/ascend/compiler/test/test_bintok.c
+++ b/ascend/compiler/test/test_bintok.c
@@ -74,11 +74,11 @@ static void test_bintok(char *filenamestem,int usebintok){
 	}else{
 		CU_TEST(0==BinTokenClearOptions());
 	}
-	error_reporter_tree_t *T1 = error_reporter_tree_start(0);
+	error_reporter_tree_start();
 	struct Instance *siminst = SimsCreateInstance(AddSymbol(filenamestem), AddSymbol("sim1"), e_normal, NULL);
 	CU_ASSERT_FATAL(siminst!=NULL);
-	CU_TEST(!error_reporter_tree_has_error(T1));
-	error_reporter_tree_end(T1);
+	CU_TEST(!error_reporter_tree_has_error());
+	error_reporter_tree_end();
 
 	/* initialise */
 #define ONLOAD "on_load"

--- a/ascend/compiler/test/test_blackbox.c
+++ b/ascend/compiler/test/test_blackbox.c
@@ -61,7 +61,7 @@ static struct Instance *load_model(const char *name,int should_have_error){
 
 	/* parse it */
 
-	error_reporter_tree_t *tree = error_reporter_tree_start(0);
+	error_reporter_tree_start();
 
 	CU_ASSERT(zz_parse() == 0);
 
@@ -69,7 +69,7 @@ static struct Instance *load_model(const char *name,int should_have_error){
 
 	/* instantiate it */
 	struct Instance *sim = SimsCreateInstance(AddSymbol(name), AddSymbol("sim1"), e_normal, NULL);
-	if(error_reporter_tree_has_error(tree)){
+	if(error_reporter_tree_has_error()){
 		if(!should_have_error){
 			CU_FAIL("Unexpected failure in SimsCreateInstance");
 		}
@@ -78,7 +78,7 @@ static struct Instance *load_model(const char *name,int should_have_error){
 			CU_FAIL("No error found although expected in SimsCreateInstance");
 		}
 	}
-	error_reporter_tree_end(tree);
+	error_reporter_tree_end();
 	return sim;
 }
 
@@ -111,7 +111,6 @@ static void test_parsefail4(void){
 	check that blackbox load and solves correctly
 */
 static void load_solve_test(const char *filenamestem, const char *modelname){
-	char env1[2*PATH_MAX];
 	int status;
 
 	/* load the file */

--- a/ascend/compiler/test/test_fixassign.c
+++ b/ascend/compiler/test/test_fixassign.c
@@ -19,6 +19,12 @@
 
 #include <test/common.h>
 #include <test/assertimpl.h>
+//#define FIXASSIGN_DEBUG
+#ifdef FIXASSIGN_DEBUG
+# define MSG CONSOLE_DEBUG
+#else
+# define MSG(ARGS...) ((void)0)
+#endif
 
 static struct Instance *load_model(const char *filename, const char *name, int assert_parse_ok, int *parsestatus){
 	struct module_t *m;
@@ -32,6 +38,9 @@ static struct Instance *load_model(const char *filename, const char *name, int a
 	strcat((char *)path,filename);
 	int openmodulestatus;
 	m = Asc_OpenModule(path,&openmodulestatus);
+	if (!m) {
+		MSG("load_model failed to OpenModule");
+	}
 	CU_ASSERT(openmodulestatus == 0);
 	CONSOLE_DEBUG("Parsing...");
 	if(assert_parse_ok){

--- a/ascend/compiler/test/test_fixfree.c
+++ b/ascend/compiler/test/test_fixfree.c
@@ -40,6 +40,12 @@
 #include <test/common.h>
 #include <test/assertimpl.h>
 
+//#define FIXFREE_DEBUG
+#ifdef FIXFREE_DEBUG
+# define MSG CONSOLE_DEBUG
+#else
+# define MSG(ARGS...) ((void)0)
+#endif
 static struct Instance *load_model(const char *name){
 	struct module_t *m;
 	int status;
@@ -49,6 +55,9 @@ static struct Instance *load_model(const char *name){
 
 	/* load the file */
 	m = Asc_OpenModule("test/compiler/fixfree.a4c",&status);
+	if (!m) {
+		MSG("load_model failed to OpenModule");
+	}
 	CU_ASSERT(status == 0);
 
 	/* parse it */

--- a/ascend/compiler/test/test_symtab.c
+++ b/ascend/compiler/test/test_symtab.c
@@ -35,10 +35,10 @@ static void test_test1(void){
 
 	symchar *s = AddSymbol("hello");
 
-	CU_TEST(NULL!=AscFindSymbol(s));
+	CU_TEST(NULL!=SCP(AscFindSymbol(s)));
 	//CU_TEST(NULL==AscFindSymbol("hellox"));
-	CU_TEST(NULL==AscFindSymbol(s+1));
-	CU_TEST(NULL==AscFindSymbol(s-1));
+	CU_TEST(NULL==SCP(AscFindSymbol(s+1)));
+	CU_TEST(NULL==SCP(AscFindSymbol(s-1)));
 
 	CU_TEST(0==strcmp(SCP(s),"hello"));
 
@@ -55,8 +55,8 @@ static void test_test1(void){
 	MSG("c = '%s'",c);
 	
 	symchar *s2 = AddSymbol(c);
-	CU_TEST(NULL!=AscFindSymbol(s2));
-	CU_TEST(0==strcmp(AscFindSymbol(s2),c));
+	CU_TEST(NULL!=SCP(AscFindSymbol(s2)));
+	CU_TEST(0==strcmp(SCP(AscFindSymbol(s2)),c));
 
 	PrintTab(1);
 

--- a/ascend/compiler/typelint.c
+++ b/ascend/compiler/typelint.c
@@ -75,57 +75,63 @@ struct errormessage {
  * The effect is obviously cumulative.
  */
 int g_parser_warnings = 0;
+#define DEM_LVL_OK 0
+#define DEM_LVL_NOTE 1
+#define DEM_LVL_WARN 2
+#define DEM_LVL_ERR 3
+#define DEM_LVL_FATAL 4
+#define DEM_LVL_UNKN 5
 
 static struct errormessage g_DefinitionErrorMessages[] = {
-  /*0*/{"No error",0},
-  {"Name of a part has been reused (failure)",3},
-  {"Name of a part has incorrect structure (failure)",3},
-  {"Name of a part/variable that does not exist",3},
-  {"Name of undefined function (failure)",3},
-  /*5*/{"Illegal right hand side type in ALIASES",3},
-  {"Illegal expression encountered (parser, lint or memory error, failure)",3},
-  {"Illegal parameter type for WILL_BE (failure)",3},
-  {"Statement not allowed in context (failure)",3},
-  {"Illegal parameter (more than 1 name per IS_A/WILL_BE - failure)",3},
-  /*10*/{"Illegal parameter reduction (LHS not defined by ancestral IS_A)",3},
-  {"Illegal parameter reduction (reassigning part - failure)",3},
-  {"Illegal parameter type for IS_A (punting). Try WILL_BE?",3},
-  {"Unverifiable name or illegal type in a relation",2},
-  {"Unverifiable name or illegal type in RHS of :==",2},
-  /*15*/{"Incorrect number of arguments passed to parameterized type. (failure)",3},
-  {"Incorrect argument passed to parameterized type. (failure)",3},
-  {"Statement possibly modifies type of parameter. (failure)",3},
-  {"Unverifiable LHS of :==, possibly undefined part or non-constant type",2},
-  {"Unverifiable LHS of :=, possibly undefined part or non-variable type",2},
-  /*20*/{"Illegal type or undefined name in RHS of := (failure)",3},
-  {"Object with incompatible type specified in refinement",3},
-  {"FOR loop index shadows previous declaration (failure)",3},
-  {"Unverifiable name or illegal type in ARE_ALIKE",2},
-  {"Illegal parameterized type in ARE_ALIKE",3},
-  /*25*/{"Illegal set of array elements in ARE_ALIKE",3},
-  {"WILL(_NOT)_BE_THE_SAME contains incorrect names.",3},
-  {"WILL_BE in WHERE clause not yet implemented.",3},
-  {"Mismatched alias array subscript and set name in ALIASES-ISA.",3},
-  {"Unverifiable FOR loop set, possibly undefined part or non-constant type", 2},
-  /*30*/{"SELECT statements are not allowed inside a FOR loop",3},
-  {"Illegal relation -- too many relational operators (<,>,=,<=,>=,<>)",3},
-  {"Illegal logical relation -- too many equality operators (!=,==)",3},
-  {"Illegal USE found outside WHEN statement",3},
-  {"Illegal FOR used in a method must be FOR/DO",3},
-  /*35*/{"Illegal FOR used in body must be FOR/CREATE",3},
-  {"Illegal ATOM attribute or relation type in ARE_THE_SAME",3},
-  {":= used outside METHOD makes models hard to debug or reuse",1},
-  {"Illegal BREAK used outside loop or SWITCH.",3},
-  {"Illegal CONTINUE used outside loop.",3},
-  /*40*/{"Illegal FALL_THROUGH used outside SWITCH.",3},
-  {"Incorrect nested argument definition for MODEL. (failure)",3},
-  {"Indexed relation has incorrect subscripts. (failure)",3},
-  {"Illegal FOR used in WHERE statements must be FOR/CHECK",3},
-  {"Illegal FOR used in parameter definitions must be FOR/EXPECT",3},
-  /*45*/{"Miscellaneous style",1},
-  {"Miscellaneous warning",2},
-  {"Miscellaneous error",3},
-  {"Unknown error encountered in statement",5}
+  /*0*/{"No error", DEM_LVL_OK},
+  {"Name of a part has been reused (failure)",DEM_LVL_ERR},
+  {"Name of a part has incorrect structure (failure)",DEM_LVL_ERR},
+  {"Name of a part/variable that does not exist",DEM_LVL_ERR},
+  {"Name of undefined function (failure)",DEM_LVL_ERR},
+  /*5*/{"Illegal right hand side type in ALIASES",DEM_LVL_ERR},
+  {"Illegal expression encountered (parser, lint or memory error, failure)",DEM_LVL_ERR},
+  {"Illegal parameter type for WILL_BE (failure)",DEM_LVL_ERR},
+  {"Statement not allowed in context (failure)",DEM_LVL_ERR},
+  {"Illegal parameter (more than 1 name per IS_A/WILL_BE - failure)",DEM_LVL_ERR},
+  /*10*/{"Illegal parameter reduction (LHS not defined by ancestral IS_A)",DEM_LVL_ERR},
+  {"Illegal parameter reduction (reassigning part - failure)",DEM_LVL_ERR},
+  {"Illegal parameter type for IS_A (punting). Try WILL_BE?",DEM_LVL_ERR},
+  {"Unverifiable name or illegal type in a relation",DEM_LVL_WARN},
+  {"Unverifiable name or illegal type in RHS of :==",DEM_LVL_WARN},
+  /*15*/{"Incorrect number of arguments passed to parameterized type. (failure)",DEM_LVL_ERR},
+  {"Incorrect argument passed to parameterized type. (failure)",DEM_LVL_ERR},
+  {"Statement possibly modifies type of parameter. (failure)",DEM_LVL_ERR},
+  {"Unverifiable LHS of :==, possibly undefined part or non-constant type",DEM_LVL_WARN},
+  {"Unverifiable LHS of :=, possibly undefined part or non-variable type",DEM_LVL_WARN},
+  /*20*/{"Illegal type or undefined name in RHS of := (failure)",DEM_LVL_ERR},
+  {"Object with incompatible type specified in refinement",DEM_LVL_ERR},
+  {"FOR loop index shadows previous declaration (failure)",DEM_LVL_ERR},
+  {"Unverifiable name or illegal type in ARE_ALIKE",DEM_LVL_WARN},
+  {"Illegal parameterized type in ARE_ALIKE",DEM_LVL_ERR},
+  /*25*/{"Illegal set of array elements in ARE_ALIKE",DEM_LVL_ERR},
+  {"WILL(_NOT)_BE_THE_SAME contains incorrect names.",DEM_LVL_ERR},
+  {"WILL_BE in WHERE clause not yet implemented.",DEM_LVL_ERR},
+  {"Mismatched alias array subscript and set name in ALIASES-ISA.",DEM_LVL_ERR},
+  {"Unverifiable FOR loop set, possibly undefined part or non-constant type",DEM_LVL_WARN},
+  /*30*/{"rELECT statements are not allowed inside a FOR loop",DEM_LVL_ERR},
+  {"Illegal relation -- too many relational operators (<,>,=,<=,>=,<>)",DEM_LVL_ERR},
+  {"Illegal logical relation -- too many equality operators (!=,==)",DEM_LVL_ERR},
+  {"Illegal USE found outside WHEN statement",DEM_LVL_ERR},
+  {"Illegal FOR used in a method must be FOR/DO",DEM_LVL_ERR},
+  /*35*/{"Illegal FOR used in body must be FOR/CREATE",DEM_LVL_ERR},
+  {"Illegal ATOM attribute or relation type in ARE_THE_SAME",DEM_LVL_ERR},
+  {":= used outside METHOD makes models hard to debug or reuse",DEM_LVL_NOTE},
+  {"Illegal BREAK used outside loop or SWITCH.",DEM_LVL_ERR},
+  {"Illegal CONTINUE used outside loop.",DEM_LVL_ERR},
+  /*40*/{"Illegal FALL_THROUGH used outside SWITCH.",DEM_LVL_ERR},
+  {"Incorrect nested argument definition for MODEL. (failure)",DEM_LVL_ERR},
+  {"Indexed relation has incorrect subscripts. (failure)",DEM_LVL_ERR},
+  {"Illegal FOR used in WHERE statements must be FOR/CHECK",DEM_LVL_ERR},
+  {"Illegal FOR used in parameter definitions must be FOR/EXPECT",DEM_LVL_ERR},
+  /*45*/{"Miscellaneous style",DEM_LVL_NOTE},
+  {"Miscellaneous warning",DEM_LVL_WARN},
+  {"Miscellaneous error",DEM_LVL_ERR},
+  {"Unknown error encountered in statement",DEM_LVL_UNKN}
 };
 
 void TypeLintErrorAuxillary(FILE *f, char *str, enum typelinterr err,
@@ -157,6 +163,8 @@ void TypeLintError(FILE *f, CONST struct Statement *stat,enum typelinterr err){
   case 2: sev = ASC_USER_WARNING; break;
   case 3: sev = ASC_USER_ERROR; break;
   case 4: sev = ASC_PROG_FATAL; break;
+  default:
+	  sev = ASC_PROG_WARNING; break;
   }
   WriteStatementError(sev,stat,1,g_DefinitionErrorMessages[err].str);
 }

--- a/ascend/general/ospath.c
+++ b/ascend/general/ospath.c
@@ -185,10 +185,6 @@ struct FilePath *ospath_new(const char *path){
 
 	ospath_cleanup(fp);
 
-#if 0
-	D(fp);
-#endif
-
 	return fp;
 }
 
@@ -202,9 +198,6 @@ struct FilePath *ospath_new_noclean(const char *path){
 	STRNCPY(fp->path,path,PATH_MAX);
 	assert(strcmp(fp->path,path)==0);
 #ifdef WINPATHS
-#if 0
-	X(fp->path);
-#endif
 	ospath_extractdriveletter(fp);
 #endif
 
@@ -253,10 +246,6 @@ struct FilePath *ospath_new_from_posix(const char *posixpath){
 	ospath_fixslash(fp->path);
 #endif
 
-#if 0
-	X(fp->path);
-#endif
-
 	ospath_cleanup(fp);
 
 	return fp;
@@ -286,24 +275,13 @@ void ospath_fixslash(char *path){
 
 	strcpy(temp,path);temp[PATH_MAX]='\0';
 
-#if 0
-	X(path);
-#endif
 
 	startslash = (strlen(temp) > 0 && temp[0] == PATH_WRONGSLASH_CHAR);
 	endslash = (strlen(temp) > 1 && temp[strlen(temp) - 1] == PATH_WRONGSLASH_CHAR);
 
-#if 0
-	V(startslash);
-	V(endslash);
-
-#endif
 	/* reset fp->path as required. */
 	STRNCPY(path, (startslash ? PATH_SEPARATOR_STR : ""), PATH_MAX);
 
-#if 0
-	M("STARTING STRTOK");
-#endif
 	for(p = STRTOK(temp, PATH_WRONGSLASH_STR,nexttok);
 			p!=NULL;
 			p = STRTOK(NULL,PATH_WRONGSLASH_STR,nexttok)
@@ -318,23 +296,14 @@ void ospath_fixslash(char *path){
 
 		STRCAT(path,p);
 	}
-#if 0
-	M("FINISHED STRTOK");
-#endif
 
 	/* put / on end as required, according to what the starting path had */
 	if(endslash && (strlen(path) > 0 ? (path[strlen(path) - 1] != PATH_SEPARATOR_CHAR) : 1))
 	{
-#if 0
-		M("adding endslash!");
-#endif
 
 		STRCAT(path, PATH_SEPARATOR_STR);
 	}
 
-#if 0
-	X(path);
-#endif
 }
 #endif
 
@@ -400,11 +369,6 @@ struct FilePath *ospath_gethomepath(void){
 void ospath_extractdriveletter(struct FilePath *fp)
 {
 	char *p;
-#if 0
-	M("SOURCE");
-	X(fp->path);
-	fprintf(stderr,"CHAR 1 = %c\n",fp->path[1]);
-#endif
 
 	/* extract the drive the path resides on... */
 	if(strlen(fp->path) >= 2 && fp->path[1] == ':')
@@ -418,11 +382,6 @@ void ospath_extractdriveletter(struct FilePath *fp)
 	}else{
 		fp->drive[0] = '\0';
 	}
-#if 0
-	M("RESULT");
-	X(fp->path);
-	X(fp->drive);
-#endif
 }
 #endif
 
@@ -438,12 +397,6 @@ void ospath_cleanup(struct FilePath *fp){
 	/*  compress the path, and resolve ~ */
 	startslash = (strlen(fp->path) > 0 && fp->path[0] == PATH_SEPARATOR_CHAR);
 	endslash = (strlen(fp->path) > 1 && fp->path[strlen(fp->path) - 1] == PATH_SEPARATOR_CHAR);
-
-#if 0
-	fprintf(stderr,"FS ON START = %d\n",startslash);
-	fprintf(stderr,"FS ON END   = %d\n",endslash);
-	fprintf(stderr,"FIRST CHAR = %c\n",fp->path[0]);
-#endif
 
 	home = ospath_gethomepath();
 
@@ -464,11 +417,6 @@ void ospath_cleanup(struct FilePath *fp){
 			p!=NULL;
 			p = STRTOK(NULL,PATH_SEPARATOR_STR,nexttok)
 	){
-#if 0
-		M("NEXT TOKEN");
-		X(p);
-		X(path+strlen(p)+1);
-#endif
 		if(strcmp(p, "~")==0){
 
 			if(p == path){ /* check that the ~ is the first character in the path */
@@ -531,9 +479,6 @@ void ospath_cleanup(struct FilePath *fp){
 		/* add the present path component */
 		STRCAT(fp->path, p);
 	}
-#if 0
-	M("FINISHED STRTOK");
-#endif
 
 	ospath_free(home);
 
@@ -693,7 +638,8 @@ struct FilePath *ospath_getparent(struct FilePath *fp)
 	return fp1;
 }
 
-#if 0
+#define ospath_gpadn_used 0
+#if ospath_gpadn_used
 // this function not yet in use
 struct FilePath *ospath_getparentatdepthn(struct FilePath *fp, unsigned depth)
 {
@@ -739,9 +685,6 @@ struct FilePath *ospath_getparentatdepthn(struct FilePath *fp, unsigned depth)
 
 		p = STRTOK(NULL, PATH_SEPARATOR_STR, nexttok);
 	}
-#if 0
-	M("FINISHED STRTOK");
-#endif
 
 	/* put / on end as required*/
 	if(strlen(temp) > 0 ? (temp[strlen(temp) - 1] != PATH_SEPARATOR_CHAR) : 1)
@@ -873,7 +816,8 @@ int ospath_isroot(struct FilePath *fp)
 	return strcmp(fp->path, PATH_SEPARATOR_STR) ? 0 : 1;
 }
 
-#if 0
+#define ospath_depth_used 0
+#if ospath_depth_used
 // disused, so far
 unsigned ospath_depth(struct FilePath *fp){
 	unsigned length;
@@ -904,9 +848,6 @@ unsigned ospath_depth(struct FilePath *fp){
 
 struct FilePath *ospath_root(struct FilePath *fp){
 #ifdef WINPATHS
-#if 0
-	M("WIN ROOT");
-#endif
 	char *temp;
 	struct FilePath *r;
 
@@ -923,9 +864,6 @@ struct FilePath *ospath_root(struct FilePath *fp){
 	return r;
 #else
 	(void)fp;
-#if 0
-	M("JUST RETURNING PATH SEP");
-#endif
 	return ospath_new(PATH_SEPARATOR_STR);
 #endif
 }
@@ -983,12 +921,6 @@ int ospath_cmp(struct FilePath *fp1, struct FilePath *fp2){
 		return 1;
 	}
 
-#if 0
-	/ now, both are valid...
-	M("BOTH ARE VALID");
-
-	/Check that paths both have drives, if applic.
-#endif
 #ifdef WINPATHS
 	if(strcmp(fp1->drive,"")==0){
 		M("PATH IS MISSING DRIVE LETTER");
@@ -1025,16 +957,10 @@ int ospath_cmp(struct FilePath *fp1, struct FilePath *fp2){
 	X(temp[0]);
 	for(p=temp[0];*p!='\0';++p){
 		*p=tolower(*p);
-#if 0
-		C(*p);
-#endif
 	}
 	X(temp[1]);
 	for(p=temp[1];*p!='\0';++p){
 		*p=tolower(*p);
-#if 0
-		C(*p);
-#endif
 	}
 	X(temp[0]);
 	X(temp[1]);
@@ -1050,10 +976,6 @@ int ospath_cmp(struct FilePath *fp1, struct FilePath *fp2){
 		STRCAT(temp[1],PATH_SEPARATOR_STR);
 	}
 
-#if 0
-	X(temp[0]);
-	X(temp[1]);
-#endif
 
 	return strcmp(temp[0],temp[1]);
 }
@@ -1062,7 +984,7 @@ struct FilePath *ospath_concat(const struct FilePath *fp1, const struct FilePath
 
 	struct FilePath *fp;
 	char temp[2][PATH_MAX+1];
-	char temp2[PATH_MAX+1];
+	char temp2[2*PATH_MAX+1];
 	struct FilePath *r;
 
 	X(fp1->path);
@@ -1114,9 +1036,11 @@ struct FilePath *ospath_concat(const struct FilePath *fp1, const struct FilePath
 #endif
 
 #if 1
-	V(strlen(temp[0]));
+	size_t s0 = strlen(temp[0]);
+	size_t s1 = strlen(temp[1]);
+	V(s0);
 	X(temp[0]);
-	V(strlen(temp[1]));
+	V(s1);
 	X(temp[1]);
 #endif
 
@@ -1127,7 +1051,10 @@ struct FilePath *ospath_concat(const struct FilePath *fp1, const struct FilePath
 
 	/* create a new path object with the two path strings appended together.*/
 	strcpy(temp2,temp[0]);
-	STRNCAT(temp2,temp[1],PATH_MAX-strlen(temp2));
+	if (s1 >= (PATH_MAX - s0)) {
+		return NULL;
+	}
+	strncpy(temp2+s0, temp[1], PATH_MAX-s0);
 #if 1
 	V(strlen(temp2));
 	X(temp2);
@@ -1168,13 +1095,7 @@ void ospath_append(struct FilePath *fp, struct FilePath *fp1){
 	X(fp2.path);
 
 	/* both paths are valid...*/
-#if 0
-	temp[0] = CALLOC(1+strlen(fp->path), sizeof(char));
-#endif
 	strcpy(temp[0], fp->path);
-#if 0
-	temp[1] = CALLOC(strlen(fp2.path), sizeof(char));
-#endif
 	strcpy(temp[1], fp2.path);
 
 	X(temp[0]);
@@ -1197,18 +1118,17 @@ void ospath_append(struct FilePath *fp, struct FilePath *fp1){
 	X(temp[0]);
 	X(temp[1]);
 
+	size_t s0 = strlen(temp[0]);
+	size_t s1 = strlen(temp[1]);
 	/*create new path string.*/
-	strcpy(fp->path,temp[0]);
-	STRNCAT(fp->path,temp[1], PATH_MAX-strlen(fp->path));
+	strcpy(fp->path, temp[0]);
+	if (s1 >= (PATH_MAX - s0)) {
+		M("ospath_append: result bigger than PATH_MAX truncated\n");
+		return;
+	}
+	strncpy(fp->path + s0, temp[1], PATH_MAX-s0);
 
 	X(fp->path);
-
-#if 0
-	ASC_FREE(temp[0]);
-	M("Freed temp[0]");
-	ASC_FREE(temp[1]);
-	M("Freed temp[1]");
-#endif
 
 	D(fp);
 	ospath_cleanup(fp);
@@ -1318,14 +1238,7 @@ struct FilePath **ospath_searchpath_new(const char *path){
 
 	pp = ASC_NEW_ARRAY(struct FilePath*, n+1);
 	for(i=0; i<n; ++i){
-#if 0
-		V(i);
-		X(list[i]);
-#endif
 		pp[i] = ospath_new_noclean(list[i]);
-#if 0
-		D(pp[i]);
-#endif
 		ASC_FREE(list[i]);
 	}
 	pp[n] = NULL;

--- a/ascend/general/test/test_list.c
+++ b/ascend/general/test/test_list.c
@@ -110,7 +110,6 @@ static void test_list(void)
   unsigned long i;
   unsigned long *pint_array[20];
   int lists_were_active = FALSE;
-  int i_initialized_lists = FALSE;
   unsigned long prior_meminuse;
 
   prior_meminuse = ascmeminuse();                     /* save meminuse() at start of function*/
@@ -136,7 +135,6 @@ static void test_list(void)
   if(FALSE == gl_pool_initialized()) {                 /* initialize list system if necessary */
     gl_init();
     gl_init_pool();
-    i_initialized_lists = TRUE;
   }else{
     lists_were_active = TRUE;
   }

--- a/ascend/general/test/test_listio.c
+++ b/ascend/general/test/test_listio.c
@@ -190,7 +190,10 @@ static void test_str(void){
   
   fputs("hello world",tmp);
   rewind(tmp);
-  fgets(buffer,4096,tmp);
+  char *rb = fgets(buffer,4096,tmp);
+  if (!rb) {
+	  CU_ASSERT(NULL=="failed to read constant from stack memory");
+  }
   CU_ASSERT(0==strcmp(buffer,"hello world"));
   rewind(tmp);
   
@@ -205,7 +208,10 @@ static void test_str(void){
 
   gl_write_list_str(tmp, list1, &gl_write_list_item_str);
   rewind(tmp);
-  fgets(buffer,4096,tmp);
+  rb = fgets(buffer,4096,tmp);
+  if (!rb) {
+	  CU_ASSERT(NULL=="failed to read gl_write_list_str result from stack memory");
+  }
   CU_ASSERT(0==strcmp(buffer,"(one,two,three)"));
 
   // TEST SORTED LIST
@@ -226,7 +232,10 @@ static void test_str(void){
   rewind(tmp);
   gl_write_list_str(tmp, list1, &gl_write_list_item_str);
   rewind(tmp);
-  fgets(buffer,4096,tmp);
+  rb = fgets(buffer,4096,tmp);
+  if (!rb) {
+	  CU_ASSERT(NULL=="failed to read long gl_write_list_str result from stack memory");
+  }
   CU_ASSERT(0==strcmp(buffer,"(TV,camera,man,person,woman)"));
 
   gl_destroy(list1);
@@ -247,7 +256,10 @@ static void test_str(void){
   rewind(tmp);
   gl_write_list_str(tmp, list1, &gl_write_list_item_str);
   rewind(tmp);
-  fgets(buffer,4096,tmp);
+  rb = fgets(buffer,4096,tmp);
+  if (!rb) {
+	  CU_ASSERT(NULL=="failed to read longer gl_write_list_str result from stack memory");
+  }
   CU_ASSERT(0==strcmp(buffer,"(one,two,(NULL),three,(NULL))"));
 
   gl_destroy(list1);

--- a/ascend/linear/linsolqr.c
+++ b/ascend/linear/linsolqr.c
@@ -1092,10 +1092,10 @@ static void adjust_row_count(struct reorder_vars *vars,int32 removed_col)
  **/
 {
    mtx_coord_t nz;
-   real64 value;
+   /* real64 value; */
    nz.col = removed_col;
    nz.row = mtx_FIRST;
-   while( value = mtx_next_in_col(vars->mtx,&nz,&(vars->reg.row)),
+   while( /* value = */ mtx_next_in_col(vars->mtx,&nz,&(vars->reg.row)),
          nz.row != mtx_LAST )
       --(vars->rowcount[nz.row]);
 }
@@ -1174,7 +1174,7 @@ static void forward_triangularize(struct reorder_vars *vars)
 {
    boolean change;
    mtx_coord_t nz;
-   real64 value;
+   // real64 value;
 
    do {
       change = FALSE;
@@ -1184,7 +1184,7 @@ static void forward_triangularize(struct reorder_vars *vars)
       if( nz.row <= vars->reg.row.high ) {
          /* found singleton row */
          nz.col = mtx_FIRST; /* this is somehow coming back with nz.col -1 */
-         value = mtx_next_in_row(vars->mtx,&nz,&(vars->reg.col));
+         /* value = */ mtx_next_in_row(vars->mtx,&nz,&(vars->reg.col));
          adjust_row_count(vars,nz.col);
          assign_row_and_col(vars,nz.row,nz.col);
          change = TRUE;
@@ -1204,7 +1204,7 @@ static int32 select_row(struct reorder_vars *vars)
    int32 i, nties=-2;  /* # elements currently defined in vars->tlist */
    int32 sum;
    mtx_coord_t nz;
-   real64 value;
+   // real64 value;
    mtx_matrix_t mtx;
    mtx_range_t *colrng, *rowrng;
 
@@ -1233,7 +1233,7 @@ static int32 select_row(struct reorder_vars *vars)
       sum = 0;
       nz.row = vars->tlist[i].ndx;
       nz.col = mtx_FIRST;
-      while( value = mtx_next_in_row(mtx,&nz,colrng),
+      while( /* value = */mtx_next_in_row(mtx,&nz,colrng),
             nz.col != mtx_LAST )
          sum += mtx_nonzeros_in_col(mtx,nz.col,rowrng);
       if( sum > max_col_count ) {
@@ -1313,7 +1313,7 @@ static void spk1_reorder(struct reorder_vars *vars)
       struct reorder_list *head;
       int32 nelts;   /* # elements "allocated" from vars->tlist */
       mtx_coord_t nz;
-      real64 value;
+      // real64 value;
 
       forward_triangularize(vars);
       assign_null_rows(vars);
@@ -1331,7 +1331,7 @@ static void spk1_reorder(struct reorder_vars *vars)
       nelts = 0;
       nz.row = select_row(vars);
       nz.col = mtx_FIRST;
-      while( value = mtx_next_in_row(mtx,&nz,&(vars->reg.col)),
+      while( /* value = */ mtx_next_in_row(mtx,&nz,&(vars->reg.col)),
             nz.col != mtx_LAST ) {
          struct reorder_list **q,*p;
 
@@ -1385,10 +1385,10 @@ static void adjust_col_count(struct creorder_vars *vars,int32 removed_row)
  **/
 {
    mtx_coord_t nz;
-   real64 value;
+   // real64 value;
    nz.row = removed_row;
    nz.col = mtx_FIRST;
-   while( value = mtx_next_in_row(vars->mtx,&nz,&(vars->reg.col)),
+   while( /* value = */ mtx_next_in_row(vars->mtx,&nz,&(vars->reg.col)),
          nz.col != mtx_LAST )
       --(vars->colcount[nz.col]);
 }
@@ -1469,7 +1469,7 @@ static void cforward_triangularize(struct creorder_vars *vars)
 
    do {
       mtx_coord_t nz;
-      real64 value;
+      // real64 value;
       change = FALSE;
       for( nz.col = vars->reg.col.low ;
           nz.col <= vars->reg.col.high && vars->colcount[nz.col] != 1;
@@ -1477,7 +1477,7 @@ static void cforward_triangularize(struct creorder_vars *vars)
       if( nz.col <= vars->reg.col.high ) {
          /* found singleton col */
          nz.row = mtx_FIRST;
-         value = mtx_next_in_col(vars->mtx,&nz,&(vars->reg.row));
+         /* value = */ mtx_next_in_col(vars->mtx,&nz,&(vars->reg.row));
          adjust_col_count(vars,nz.row);
          assign_col_and_row(vars,nz.col,nz.row);
          change = TRUE;
@@ -1497,7 +1497,7 @@ static int32 select_col(struct creorder_vars *vars)
    int32 i, nties=-2;  /* # elements currently defined in vars->tlist */
    int32 sum;
    mtx_coord_t nz;
-   real64 value;
+   // real64 value;
    mtx_matrix_t mtx;
    mtx_range_t *colrng, *rowrng;
 
@@ -1526,7 +1526,7 @@ static int32 select_col(struct creorder_vars *vars)
       sum = 0;
       nz.row = mtx_FIRST;
       nz.col = vars->tlist[i].ndx;
-      while( value = mtx_next_in_col(mtx,&nz,rowrng),
+      while( /* value = */ mtx_next_in_col(mtx,&nz,rowrng),
             nz.row != mtx_LAST )
          sum += mtx_nonzeros_in_row(mtx,nz.row,colrng);
       if( sum > max_row_count ) {
@@ -1611,7 +1611,7 @@ static void tspk1_reorder(struct creorder_vars *vars)
       struct creorder_list *head;
       int32 nelts;   /* # elements "allocated" from vars->tlist */
       mtx_coord_t nz;
-      real64 value;
+      // real64 value;
 
       cforward_triangularize(vars);
       assign_null_cols(vars);
@@ -1629,7 +1629,7 @@ static void tspk1_reorder(struct creorder_vars *vars)
       nelts = 0;
       nz.row = mtx_FIRST;
       nz.col = select_col(vars);
-      while( value = mtx_next_in_col(mtx,&nz,&(vars->reg.row)),
+      while( /* value = */ mtx_next_in_col(mtx,&nz,&(vars->reg.row)),
             nz.row != mtx_LAST ) {
          struct creorder_list **q,*p;
 
@@ -1665,8 +1665,8 @@ static boolean nonempty_row(mtx_matrix_t mtx,int32 row)
  **/
 {
    mtx_coord_t nz;
-   real64 value;
-   value = mtx_next_in_row(mtx, mtx_coord(&nz,row,mtx_FIRST), mtx_ALL_COLS);
+   // real64 value;
+   /* value = */ mtx_next_in_row(mtx, mtx_coord(&nz,row,mtx_FIRST), mtx_ALL_COLS);
    return( nz.col != mtx_LAST );
 }
 
@@ -1676,8 +1676,8 @@ static boolean nonempty_col(mtx_matrix_t mtx,int32 col)
  **/
 {
    mtx_coord_t nz;
-   real64 value;
-   value = mtx_next_in_col(mtx, mtx_coord(&nz,mtx_FIRST,col), mtx_ALL_ROWS);
+   // real64 value;
+   /* value = */ mtx_next_in_col(mtx, mtx_coord(&nz,mtx_FIRST,col), mtx_ALL_ROWS);
    return( nz.row != mtx_LAST );
 }
 
@@ -2365,7 +2365,7 @@ static void qr_apply_householder(linsolqr_system_t sys,
  */
 {
   static int32 *hhrowlist=NULL, listlen=0;
-  real64 *hhcol, *hhrow, tauc, value,xdothhcol;
+  real64 *hhcol, *hhrow, tauc, /* value, */ xdothhcol;
   int32 col,row,collim,rowlim;
   mtx_matrix_t mtx;
   mtx_coord_t coord;
@@ -2435,7 +2435,7 @@ static void qr_apply_householder(linsolqr_system_t sys,
     coord.row=mtx_FIRST;
     coord.col=curcol;
     /* do transform */
-    while( value = mtx_next_in_col(mtx,&coord,rng),
+    while( /* value = */ mtx_next_in_col(mtx,&coord,rng),
            coord.row != mtx_LAST ) {
       if (hhrowdense) {
         mtx_old_add_row_sparse(mtx,coord.row,hhrow,-tauc*hhcol[coord.row],
@@ -2460,7 +2460,7 @@ static void qr_apply_householder(linsolqr_system_t sys,
 
     /* rezero used part of hhcol and do housekeeping on changed rows */
     coord.row=mtx_FIRST;
-    while( value = mtx_next_in_col(mtx,&coord,rng),
+    while( /* value = */ mtx_next_in_col(mtx,&coord,rng),
            coord.row != mtx_LAST ) {
       mtx_del_zr_in_row(mtx,coord.row);
       /*safe only because we cleaned curcol in get_householder */
@@ -3781,7 +3781,7 @@ int linsolqr_setup_ngslv(linsolqr_system_t sys,
                          real64 *tmpvec)
 {
    struct rhs_list *rl;
-   int status=0,k;
+   int k;
 
    CHECK_SYSTEM(sys);
    if( !sys->factored ) {
@@ -3809,8 +3809,8 @@ int linsolqr_setup_ngslv(linsolqr_system_t sys,
       forward_substitute2(sys,rl->varvalue,rl->transpose);
       /* we now have inv(L11)*inv(U11)*B1 stored in rl->varvalue */
 
-      status=1;
    } else {
+
      if( NOTNULL(rhs) ) {
        ERROR_REPORTER_HERE(ASC_PROG_ERR,"Rhs not found on list.");
      } else {

--- a/ascend/linear/mtx_basic.c
+++ b/ascend/linear/mtx_basic.c
@@ -2920,9 +2920,8 @@ static void mtx_write_perm(FILE *fp,int32 ord,int32 *arr){
 
 static void mtx_read_perm(FILE *fp,int32 ord,int32 *arr){
   int32 i;
-  int nitems;
   for (i=0; i<ord;i++) {
-    nitems = fscanf(fp,"%d",&(arr[i]));
+    int nitems = fscanf(fp,"%d",&(arr[i]));
     if (nitems != 1) {
       FPRINTF(g_mtxerr, "mtx_read_perm: ran out of data at %d\n", i);
       return;
@@ -3003,25 +3002,15 @@ static int getregion(FILE* fp, mtx_region_t *reg) {
 }
 
 static int getcoef(FILE* fp, int *row, int *col, double *val){
-  char buf[80];
   int nitems;
-  nitems = fscanf(fp,"%d %d",row,col);
+  nitems = fscanf(fp,"%d %d %lg",row,col, val);
   if( nitems == EOF) {
     return 0;
   }
-  if (nitems != 2) {
-    FPRINTF(g_mtxerr, "mtx_read_region: getcoef:ran out of data: coord\n");
+  if (nitems != 3) {
+    FPRINTF(g_mtxerr, "mtx_read_region: getcoef:ran out of data: i j val\n");
     return 0;
   }
-  nitems = fscanf(fp,"%s",buf);
-  if( nitems == EOF) {
-    return 0;
-  }
-  if (nitems != 1) {
-    FPRINTF(g_mtxerr, "mtx_read_region: getcoef:ran out of data: value\n");
-    return 0;
-  }
-  *val=strtod(buf,NULL);
   return 1;
 }
 

--- a/ascend/linear/rankiba2.c
+++ b/ascend/linear/rankiba2.c
@@ -564,12 +564,11 @@ void eliminate_row2_ba(	mtx_matrix_t mtx,
    * all N from low to origin will be eliminated.
    */
   /* old */
-  int32 j,low,high;
+  int32 j,low;
   double tmpval;
 
   /* pseudo curcol limits */
   low = rng->low;	/* don't change this. pccleft needs it */
-  high = rng->high;
 
 #if RBADEBUG
    FPRINTF(stderr,"Elim Row: %d\n",row);

--- a/ascend/packages/kvalues.c
+++ b/ascend/packages/kvalues.c
@@ -338,9 +338,15 @@ static int DoCalculation(struct BBoxInterp *interp,
   offset = ncomps+1;
   TotP = inputs[offset];
 
+  int unknown;
   for (c=0;c<ncomps;c++) {
     vp.component = problem->components[c];	/* get component name */
-    result = GetCoefficients(&vp);		/* get antoines coeffs */
+    unknown = GetCoefficients(&vp);		/* get antoines coeffs */
+    if (unknown) {
+	    result = 1;
+	    interp->status = calc_incorrect_args;
+	    goto cleanup;
+    }
     SatP[c] = exp(vp.a - vp.b/(T + vp.c));	/* calc satP */
     vap_frac[c] = SatP[c] * liq_frac[c] / TotP;
   }
@@ -378,11 +384,13 @@ static int DoCalculation(struct BBoxInterp *interp,
     tmp++;
   }
 
+cleanup:
   free((char *)liq_frac);
   free((char *)vap_frac);
   free((char *)SatP);
-  interp->status = calc_all_ok;
-  return 0;
+  if (!result)
+    interp->status = calc_all_ok;
+  return result;
 }
 
 int kvalues_fex(struct BBoxInterp *interp,

--- a/ascend/packages/test/test_defaultall.c
+++ b/ascend/packages/test/test_defaultall.c
@@ -39,6 +39,12 @@
 
 #include <test/common.h>
 #include <test/assertimpl.h>
+//#define TDEFALL_DEBUG
+#ifdef TDEFALL_DEBUG
+# define MSG CONSOLE_DEBUG
+#else
+# define MSG(ARGS...) ((void)0)
+#endif
 
 static enum Proc_enum run_method(struct Instance *sim, const char *methodname){
 	CONSOLE_DEBUG("Running '%s'...",methodname);
@@ -61,6 +67,9 @@ static struct Instance *load_and_initialise(const char *fname, const char *model
 	
 	/* load the file */
 	m = Asc_OpenModule(fname,&status);
+	if (!m) {
+		MSG("load_and_initialized failed to OpenModule");
+	}
 	CU_ASSERT(status == 0);
 
 	/* parse it */

--- a/ascend/solver/test/test_cmslv.c
+++ b/ascend/solver/test/test_cmslv.c
@@ -42,6 +42,12 @@
 #include <ascend/system/slv_server.h>
 
 #include <test/common.h>
+//#define TCMSLV_DEBUG
+#ifdef TCMSLV_DEBUG
+# define MSG CONSOLE_DEBUG
+#else
+# define MSG(ARGS...) ((void)0)
+#endif
 
 /*
 	Test solving a simple CMSlv model
@@ -62,6 +68,9 @@ static void test_cmslv(const char *filenamestem){
 	{
 		int status;
 		m = Asc_OpenModule(path,&status);
+		if (!m) {
+			MSG("test_cmslv: failed OpenModule");
+		}
 		CU_ASSERT(status == 0);
 	}
 

--- a/ascend/solver/test/test_datareader.c
+++ b/ascend/solver/test/test_datareader.c
@@ -90,11 +90,11 @@ static void dr_load_solve_test_qrslv(const char *librarypath, const char *modelf
 
 	/* instantiate it */
 	CONSOLE_DEBUG("Instantiating '%s'",modelfile);
-	error_reporter_tree_t *tree = error_reporter_tree_start(0);
+	error_reporter_tree_start();
 	struct Instance *siminst = SimsCreateInstance(AddSymbol(modelname), AddSymbol("sim1"), e_normal, NULL);
 
-	int has_error = error_reporter_tree_has_error(tree);
-	error_reporter_tree_end(tree);	
+	int has_error = error_reporter_tree_has_error();
+	error_reporter_tree_end();
 	CONSOLE_DEBUG("has_error = %d",has_error);
 	if(instantiatefail){
 		CU_TEST(has_error);

--- a/ascend/solver/test/test_ipopt.c
+++ b/ascend/solver/test/test_ipopt.c
@@ -42,6 +42,13 @@
 #include <ascend/system/slv_server.h>
 
 #include <test/common.h>
+//#define TIPOPT
+#ifdef TIPOPT_DEBUG
+# define MSG CONSOLE_DEBUG
+#else
+# define MSG(ARGS...) ((void)0)
+#endif
+
 
 /*
 	Test solving a simple IPOPT model
@@ -62,6 +69,9 @@ static void test_ipopt(const char *filenamestem){
 	{
 		int status;
 		m = Asc_OpenModule(path,&status);
+		if (!m) {
+			MSG("test_ipopt: failed OpenModule");
+		}
 		CU_ASSERT(status == 0);
 	}
 

--- a/ascend/solver/test/test_slvreq.c
+++ b/ascend/solver/test/test_slvreq.c
@@ -41,6 +41,12 @@
 #include <ascend/system/slv_server.h>
 
 #include <test/common.h>
+//#define TSR_DEBUG
+#ifdef TSR_DEBUG
+# define MSG CONSOLE_DEBUG
+#else
+# define MSG(ARGS...) ((void)0)
+#endif
 
 typedef struct SlvReqC_struct{
 	struct Instance *siminst;
@@ -194,6 +200,9 @@ static void test_slvreq_c(void){
 	/* load the file */
 #define TESTFILE "test2"
 	m = Asc_OpenModule("test/slvreq/" TESTFILE ".a4c",&status);
+	if (!m) {
+		MSG("test_ipopt: failed OpenModule");
+	}
 	CU_ASSERT(status == 0);
 
 	/* parse it */

--- a/ascend/solver/test/test_sunpos.c
+++ b/ascend/solver/test/test_sunpos.c
@@ -42,6 +42,12 @@
 #include <ascend/system/slv_server.h>
 
 #include <test/common.h>
+//#define TSP_DEBUG
+#ifdef TSP_DEBUG
+# define MSG CONSOLE_DEBUG
+#else
+# define MSG(ARGS...) ((void)0)
+#endif
 
 /**
 	Reusable function for the standard process of loading, initialising, solving
@@ -71,7 +77,10 @@ static void load_solve_test_qrslv(const char *librarypath, const char *modelfile
 	CU_ASSERT_FATAL(qrslv_index != -1);
 
 	/* load the model file */
-	Asc_OpenModule(modelfile,&status);
+	struct module_t *m = Asc_OpenModule(modelfile,&status);
+	if (!m) {
+		MSG("load_solve_test_qrslv failed OpenModule");
+	}
 	CU_ASSERT(status == 0);
 	if(status){
 		Asc_CompilerDestroy();

--- a/ascend/system/analyze.c
+++ b/ascend/system/analyze.c
@@ -620,7 +620,7 @@ void *classify_instance(struct Instance *inst, VOIDPTR vp){
           }else{
 	if(ip->u.v.deriv==-1){
 		//printf("\n smth smth \n");
-		struct solver_ipdata *original_indep_var;
+		struct solver_ipdata *original_indep_var = NULL;
 		if(gl_length(p_data->indepvars) != 0) {
 			original_indep_var = (struct solver_ipdata *)gl_fetch(p_data->indepvars,1);
 			//printf("\n asadada %d \n",original_indep_var->i == inst);

--- a/ascend/system/block.c
+++ b/ascend/system/block.c
@@ -705,8 +705,8 @@ int slv_set_up_block(slv_system_t sys,int bnum)
   mtx_region_t reg;
   const mtx_block_t *b;
   int32 c,vlen,rlen;
-  var_filter_t vf;
-  rel_filter_t rf;
+  // var_filter_t vf;
+  // rel_filter_t rf;
 
   if (sys==NULL) return 1;
   rlen = slv_get_num_solvers_rels(sys);
@@ -718,10 +718,10 @@ int slv_set_up_block(slv_system_t sys,int bnum)
   assert(rp!=NULL);
   assert(vp!=NULL);
 
-  rf.matchbits = (REL_INCLUDED | REL_EQUALITY | REL_INBLOCK | REL_ACTIVE);
-  rf.matchvalue = (REL_INCLUDED | REL_EQUALITY | REL_INBLOCK | REL_ACTIVE);
-  vf.matchbits =(VAR_INCIDENT |VAR_SVAR | VAR_FIXED |VAR_INBLOCK | VAR_ACTIVE);
-  vf.matchvalue = (VAR_INCIDENT | VAR_SVAR | VAR_INBLOCK | VAR_ACTIVE);
+  // rf.matchbits = (REL_INCLUDED | REL_EQUALITY | REL_INBLOCK | REL_ACTIVE);
+  // rf.matchvalue = (REL_INCLUDED | REL_EQUALITY | REL_INBLOCK | REL_ACTIVE);
+  // vf.matchbits =(VAR_INCIDENT |VAR_SVAR | VAR_FIXED |VAR_INBLOCK | VAR_ACTIVE);
+  // vf.matchvalue = (VAR_INCIDENT | VAR_SVAR | VAR_INBLOCK | VAR_ACTIVE);
 
   b = slv_get_solvers_blocks(sys);
   assert(b!=NULL);

--- a/ascend/system/bndman.c
+++ b/ascend/system/bndman.c
@@ -75,13 +75,13 @@ int32 bndman_log_eval(struct bnd_boundary *bnd){
 int32 bndman_calc_satisfied(struct bnd_boundary *bnd){
   int32 logres;
   struct rel_relation *rel;
-  real64 res,tol;
+  real64 tol;
   boolean rstat;
 
   switch(bnd_kind(bnd)) {
     case e_bnd_rel:
       rel = bnd_rel(bnd_real_cond(bnd));
-      res = bndman_real_eval(bnd); /* force to reset real residual */
+      (void)bndman_real_eval(bnd); /* force to reset real residual */
       tol = bnd_tolerance(bnd);
       rstat = relman_calc_satisfied(rel,tol);
       if (rstat) {

--- a/ascend/system/cond_config.c
+++ b/ascend/system/cond_config.c
@@ -838,13 +838,13 @@ static void set_active_rels_in_cases(int32 *cases, int32 ncases,
 void set_active_rels_in_subregion(slv_system_t sys, int32 *cases,
 				  int32 ncases, struct gl_list_t *disvars)
 {
-  struct rel_relation **solverrl;
+  // struct rel_relation **solverrl;
   struct dis_discrete *dis;
   struct gl_list_t *whens;
   struct w_when *when;
   int32 d,dlen,w,wlen;
 
-  solverrl = slv_get_solvers_rel_list(sys);
+  /* solverrl = */ slv_get_solvers_rel_list(sys); // do we need this for a side effect?
 
   SET_WHENDEBUG(sys)
 
@@ -1003,7 +1003,10 @@ static int32 compare_alternative_cases(struct when_case *cur_case1,
   struct gl_list_t *rel_list1, *rel_list2;
   struct rel_relation *rel1, *rel2;
   struct var_variable **inc1, **inc2;
-  int32 numcase1, numcase2;
+#ifdef PREANALYSIS_DEBUG
+  int32 numcase1;
+  int32 numcase2;
+#endif
   int32 nrel1, nrel2;
   int32 nvar1, nvar2;
   int32 v,r, ind1, ind2;
@@ -1011,9 +1014,9 @@ static int32 compare_alternative_cases(struct when_case *cur_case1,
   int32 *ninc1, *ninc2;
   int32 *ord_ind1, *ord_ind2;
 
+#ifdef PREANALYSIS_DEBUG
   numcase1 = when_case_case_number(cur_case1);
   numcase2 = when_case_case_number(cur_case2);
-#ifdef PREANALYSIS_DEBUG
   FPRINTF(ASCERR,"Making comparison of CASEs:\n");
   FPRINTF(ASCERR,"case A = %d  case B = %d \n",numcase1,numcase2);
 #endif
@@ -1781,7 +1784,7 @@ void configure_conditional_problem(int32 numwhens,
                                    struct logrel_relation **solverll,
 				   struct var_variable **mastervl)
 {
-  int32 w,result;
+  int32 w;
   struct w_when *when;
 
   /* Enumerate cases in when's */
@@ -1796,7 +1799,7 @@ void configure_conditional_problem(int32 numwhens,
   /* get structure of the different alternatives */
   for (w = 0; w < numwhens; w++) {
     when = whenlist[w];
-    result = analyze_alternative_structures_in_when(when,mastervl);
+    (void)analyze_alternative_structures_in_when(when,mastervl);
   }
 
   /*

--- a/ascend/system/rel.c
+++ b/ascend/system/rel.c
@@ -113,7 +113,6 @@ static struct rel_relation *rel_copy(const struct rel_relation *rel){
 struct rel_relation *
 rel_create(SlvBackendToken instance, struct rel_relation *newrel)
 {
-  CONST struct relation *instance_relation;
 #ifdef DIEDIEDIE
   struct ExtCallNode *ext;
 #endif
@@ -126,7 +125,7 @@ rel_create(SlvBackendToken instance, struct rel_relation *newrel)
   }
   assert(newrel!=NULL);
   newrel->instance = instance;
-  instance_relation = GetInstanceRelation(IPTR(instance),&ctype);
+  (void)GetInstanceRelation(IPTR(instance),&ctype); /* get just ctype */
   switch (ctype) {
   case e_token:
     newrel->type = e_rel_token;

--- a/ascend/system/slv_stdcalls.c
+++ b/ascend/system/slv_stdcalls.c
@@ -104,7 +104,10 @@ void slv_sort_rels_and_vars(slv_system_t sys
   struct rel_relation **rp, **rtmp, *rel;
   struct var_variable **vp, **vtmp, *var;
 
-  int32 nrow,ncol,rlen,vlen,rel_tmp_end;
+#if DEBUG_SLVSORT
+  int32 nrow,ncol;
+#endif
+  int32 rlen,vlen,rel_tmp_end;
   int32 r,c,var_tmp_end,len;
   var_filter_t vf;
   rel_filter_t rf;
@@ -137,7 +140,7 @@ void slv_sort_rels_and_vars(slv_system_t sys
   vf.matchvalue = (VAR_INCIDENT | VAR_SVAR | VAR_ACTIVE);
 
   /* count rows and cols */
-#if 0
+#if DEBUG_SLVSORT
   nrow = slv_count_solvers_rels(sys,&rf);
   ncol = slv_count_solvers_vars(sys,&vf);
   (void)ncol; (void)nrow;

--- a/ascend/utilities/test/shlib_test3.c
+++ b/ascend/utilities/test/shlib_test3.c
@@ -4,7 +4,7 @@ typedef int (*initFunc)(void);
 typedef int (*isInitializedFunc)(void);
 typedef void (*cleanupFunc)(void);
 
-ASC_DLLSPEC int valuex = FALSE;
+/* ASC_DLLSPEC */ int valuex = FALSE;
                           
 ASC_DLLSPEC int init(void){
   valuex = TRUE;

--- a/ascend/utilities/test/test_ascEnvVar.c
+++ b/ascend/utilities/test/test_ascEnvVar.c
@@ -54,9 +54,9 @@ static void test_ascEnvVar(void)
   char str_path_ss2[STR_LEN];
   char str_path_ss3[STR_LEN];
 
-  char str_pathbig[MAX_ENV_VAR_LENGTH*3];
-  char str_pathbig_ss1[MAX_ENV_VAR_LENGTH*3];
-  char str_pathbig_ss2[MAX_ENV_VAR_LENGTH*3];
+  char str_pathbig[MAX_ENV_VAR_LENGTH*3+1];
+  char str_pathbig_ss1[MAX_ENV_VAR_LENGTH*3+1];
+  char str_pathbig_ss2[MAX_ENV_VAR_LENGTH*3+1];
 
   int elem_count;
   const char **paths;
@@ -148,12 +148,12 @@ static void test_ascEnvVar(void)
   CU_TEST(!strcmp(paths[0], str_path_ss1));
   ascfree(paths);
 
-  SNPRINTF(str_path, STR_LEN-1, "%c", PATHDIV);
+  SNPRINTF(str_path, STR_LEN-1, "%c", PATHDIV); /* "PATH=:" */
 
   CU_TEST(0 == Asc_SetPathList("envar2e3", str_path));  /* 2 elements, both empty */
   paths = Asc_GetPathList("envar2e3", &elem_count);
   CU_TEST_FATAL(NULL != paths);
-  CU_TEST(paths[0] == '\0');
+  CU_TEST(paths[0][0] == '\0');
   CU_TEST(0 == elem_count);
   if (NULL != paths) ascfree(paths);
 
@@ -162,7 +162,7 @@ static void test_ascEnvVar(void)
   CU_TEST(0 == Asc_SetPathList("envar2e4", str_path));  /* 2 elements, both empty with ws */
   paths = Asc_GetPathList("envar2e4", &elem_count);
   CU_TEST_FATAL(NULL != paths);
-  CU_TEST(paths[0] == '\0');
+  CU_TEST(paths[0][0] == '\0');
   CU_TEST(0 == elem_count);
   if (NULL != paths) ascfree(paths);
 
@@ -216,7 +216,7 @@ static void test_ascEnvVar(void)
   CU_TEST(0 == Asc_SetPathList("envar3e3", str_path));  /* 3 elements - all empty */
   paths = Asc_GetPathList("envar3e3", &elem_count);
   CU_TEST_FATAL(NULL != paths);
-  CU_TEST(paths[0] == '\0');
+  CU_TEST(paths[0][0] == '\0');
   CU_TEST(0 == elem_count);
   if (NULL != paths) ascfree(paths);
 
@@ -377,7 +377,7 @@ static void test_ascEnvVar(void)
   CU_TEST(0 == Asc_PutEnv(str_path));                   /* 2 elements, both empty */
   paths = Asc_GetPathList("envar2e3", &elem_count);
   CU_TEST_FATAL(NULL != paths);
-  CU_TEST(paths[0] == '\0');
+  CU_TEST(paths[0][0] == '\0');
   CU_TEST(0 == elem_count);
   if (NULL != paths) ascfree(paths);
 
@@ -386,7 +386,7 @@ static void test_ascEnvVar(void)
   CU_TEST(0 == Asc_PutEnv(str_path));                   /* 2 elements, both empty with ws */
   paths = Asc_GetPathList("envar2e4", &elem_count);
   CU_TEST_FATAL(NULL != paths);
-  CU_TEST(paths[0] == '\0');
+  CU_TEST(paths[0][0] == '\0');
   CU_TEST(0 == elem_count);
   if (NULL != paths) ascfree(paths);
 
@@ -440,19 +440,20 @@ static void test_ascEnvVar(void)
   CU_TEST(0 == Asc_PutEnv(str_path));                   /* 3 elements - all empty */
   paths = Asc_GetPathList("envar3e3", &elem_count);
   CU_TEST_FATAL(NULL != paths);
-  CU_TEST(paths[0] == '\0');
+  CU_TEST(paths[0][0] == '\0');
   CU_TEST(0 == elem_count);
   if (NULL != paths) ascfree(paths);
 
-  memset(str_pathbig_ss1, '.', MAX_ENV_VAR_LENGTH-9);
-  str_pathbig_ss1[MAX_ENV_VAR_LENGTH-9] = '\0';
-  SNPRINTF(str_pathbig, MAX_ENV_VAR_LENGTH-1, "envar4=%s", str_pathbig_ss1);
+  char str_pathbig_ss1_a[MAX_ENV_VAR_LENGTH-1];
+  memset(str_pathbig_ss1_a, '.', MAX_ENV_VAR_LENGTH-9);
+  str_pathbig_ss1_a[MAX_ENV_VAR_LENGTH-9] = '\0';
+  SNPRINTF(str_pathbig, MAX_ENV_VAR_LENGTH-1, "envar4=%s", str_pathbig_ss1_a);
 
   CU_TEST(0 == Asc_PutEnv(str_pathbig));                /* large string at max length */
   paths = Asc_GetPathList("envar4", &elem_count);
   CU_TEST_FATAL(NULL != paths);
   CU_TEST_FATAL(1 == elem_count);
-  CU_TEST(!strcmp(paths[0], str_pathbig_ss1));
+  CU_TEST(!strcmp(paths[0], str_pathbig_ss1_a));
   ascfree(paths);
 
   memset(str_pathbig_ss1, 'a', MAX_ENV_VAR_LENGTH-3);

--- a/ascend/utilities/test/test_error.c
+++ b/ascend/utilities/test/test_error.c
@@ -105,21 +105,33 @@ static void test_error(void){
 #define CHECKIT(STR)\
 	fprintf(tmp,"\n");\
 	rewind(tmp); \
-	fgets(output,4096,tmp); \
-	MSG("OUTPUT: %s",output);\
-	sprintf(gold,STR "\n",myfile,myline); \
-	MSG("GOLD  : %s",gold);\
-	CU_ASSERT(0==strcmp(output,gold));\
+	{ char *op = \
+		fgets(output,4096,tmp); \
+		if (op) { \
+			MSG("OUTPUT: %s",output);\
+			sprintf(gold,STR "\n",myfile,myline); \
+			MSG("GOLD  : %s",gold);\
+			CU_ASSERT(0==strcmp(output,gold));\
+		} else { \
+			CU_ASSERT(NULL=="fgets failed on tmpfile");\
+		} \
+	}\
 	rewind(tmp);\
 	output[0]='\0';
 #define CHECKIT1(STR)\
 	fprintf(tmp,"\n");\
 	rewind(tmp); \
-	fgets(output,4096,tmp); \
-	MSG("OUTPUT: [%s]",output);\
-	sprintf(gold,STR "\n"); \
-	MSG("GOLD  : [%s]",gold);\
-	CU_ASSERT(0==strcmp(output,gold));\
+	{ char *op = \
+		fgets(output,4096,tmp); \
+		if (op) { \
+			MSG("OUTPUT: [%s]",output);\
+			sprintf(gold,STR "\n"); \
+			MSG("GOLD  : [%s]",gold);\
+			CU_ASSERT(0==strcmp(output,gold));\
+		} else { \
+			CU_ASSERT(NULL=="fgets failed on tmpfile");\
+		} \
+	} \
 	rewind(tmp);\
 	output[0]='\0';
 	

--- a/mmio/mmio.c
+++ b/mmio/mmio.c
@@ -72,12 +72,18 @@ int mm_read_unsymmetric_sparse(const char *fname, int *M_, int *N_, int *nz_,
     /*   specifier as in "%lg", "%lf", "%le", otherwise errors will occur */
     /*  (ANSI C X3.159-1989, Sec. 4.9.6.2, p. 136 lines 13-15)            */
  
+    int nitems;
     for (i=0; i<nz; i++)
     {
-        fscanf(f, "%d %d %lg\n", &I[i], &J[i], &val[i]);
+        nitems = fscanf(f, "%d %d %lg\n", &I[i], &J[i], &val[i]);
+        if (nitems !=3) {
+            fprintf(stderr, "short data in mm_read_unsymmetric_sparse");
+            goto out;
+        }
         I[i]--;  /* adjust from 1-based to 0-based */
         J[i]--;
     }
+ out:
     fclose(f);
  
     return 0;
@@ -457,14 +463,13 @@ char  *mm_typecode_to_str(MM_typecode matcode)
 {
     char buffer[MM_MAX_LINE_LENGTH];
     char *types[4];
-	//char *strdup(const char *);
-    int error =0;
 
     /* check for MTX type */
     if (mm_is_matrix(matcode)) 
         types[0] = MM_MTX_STR;
-    else
-        error=1;
+    else {
+        types[0] = "MTX-ERROR";
+    }
 
     /* check for CRD or ARR matrix */
     if (mm_is_sparse(matcode))


### PR DESCRIPTION
removing dead code in a few spots as well.
fixed several incorrect tests for empty string in envvar test.
fixed error_reporter use of outdated function arguments.
checked all returns of fscanf.
checked returns of kvalues example.
got rid of magic numbers in g_definitionerrormessages.