### PR TITLE
remove use of 'register' keyword, to not tickle weak c++ compilers

### DIFF
--- a/ascend/compiler/anoncopy.c
+++ b/ascend/compiler/anoncopy.c
@@ -107,10 +107,10 @@ struct Instance *CopyAnonRelationInstance(struct Instance *newparent,
 			                  struct gl_list_t *copyvars,
 					struct pairlist_t *bboxtable)
 {
-  register struct RelationInstance *src,*result;
+  struct RelationInstance *src,*result;
   struct relation *rel;
   enum Expr_enum type;
-  register unsigned long size;
+  unsigned long size;
 
 #if TIMECOMPILER
   /* hack to get some statistics. BAA */
@@ -162,9 +162,9 @@ struct gl_list_t *CopyAnonArrayChildPtrs(struct Instance *newparent,
                                          struct gl_list_t *copyvars,
 					struct pairlist_t *bboxtable)
 {
-  register struct gl_list_t *result;
-  register unsigned long length,c;
-  register struct ArrayChild *new,*src;
+  struct gl_list_t *result;
+  unsigned long length,c;
+  struct ArrayChild *new,*src;
   if (list!=NULL){
     length = gl_length(list);
     if (length) {
@@ -217,7 +217,7 @@ CopyAnonRelationArrayInstance(struct Instance *newparent,
                               struct gl_list_t *copyvars,
 				struct pairlist_t *bboxtable)
 {
-  register struct ArrayInstance *ary,*result;
+  struct ArrayInstance *ary,*result;
   AssertMemory(proto);
   ary = ARY_INST(proto);
   result = ARY_INST(ASC_NEW(struct ArrayInstance));

--- a/ascend/compiler/arrayinst.c
+++ b/ascend/compiler/arrayinst.c
@@ -177,7 +177,7 @@ void ApplyToLeaves(struct Instance *i, AVProc func, int depth)
  */
 void ArrayVisitLocalLeaves(struct Instance *i, AVProc func)
 {
-  register struct ArrayInstance *ary;
+  struct ArrayInstance *ary;
   int depth;
   AssertMemory(i);
   ary = ARY_INST(i);
@@ -225,9 +225,9 @@ struct gl_list_t *CollectArrayInstances(CONST struct Instance *i,
 
 int RectangleArrayExpanded(CONST struct Instance *i)
 {
-  register struct ArrayInstance *ary;
-  register struct ArrayChild *ptr;
-  register unsigned long number;
+  struct ArrayInstance *ary;
+  struct ArrayChild *ptr;
+  unsigned long number;
   AssertMemory(i);
   ary = ARY_INST(i);
   if ((ary->t==ARRAY_INT_INST)||(ary->t==ARRAY_ENUM_INST)) {
@@ -424,9 +424,9 @@ int RectangleSubscriptsMatch(CONST struct Instance *parent,
 
 unsigned long NextToExpand(CONST struct Instance *i)
 {
-  register struct ArrayInstance *ary;
-  register struct ArrayChild *ptr;
-  register unsigned long number,c;
+  struct ArrayInstance *ary;
+  struct ArrayChild *ptr;
+  unsigned long number,c;
   AssertMemory(i);
   ary = ARY_INST(i);
   if ((ary->t==ARRAY_INT_INST)||(ary->t==ARRAY_ENUM_INST)) {
@@ -453,7 +453,7 @@ unsigned long NextToExpand(CONST struct Instance *i)
 
 unsigned long NumberofDereferences(CONST struct Instance *i)
 {
-  register struct ArrayInstance *ary;
+  struct ArrayInstance *ary;
   AssertMemory(i);
   ary = ARY_INST(i);
   if ((ary->t==ARRAY_INT_INST)||(ary->t==ARRAY_ENUM_INST)) {
@@ -625,8 +625,8 @@ void ExpandIntegerSet(struct ArrayInstance *i, struct set_t *set,
                       struct Instance *rhsinst, struct Instance *arginst,
                       struct gl_list_t *rhslist)
 {
-  register unsigned long c,len;
-  register struct ArrayChild *ptr, *rptr;
+  unsigned long c,len;
+  struct ArrayChild *ptr, *rptr;
   AssertMemory(i);
   AssertMemory(set);
   assert(rhslist==NULL||rhsinst==NULL); /* one type of alias or other */
@@ -667,8 +667,8 @@ void ExpandStringSet(struct ArrayInstance *i, struct set_t *set,
                      struct Instance *rhsinst, struct Instance *arginst,
                      struct gl_list_t *rhslist)
 {
-  register unsigned long c,len;
-  register struct ArrayChild *ptr, *rptr;
+  unsigned long c,len;
+  struct ArrayChild *ptr, *rptr;
   AssertMemory(i);
   AssertMemory(set);
   assert(rhslist==NULL||rhsinst==NULL); /* one type of alias or other */
@@ -737,9 +737,9 @@ void RecursiveExpand(struct Instance *i, unsigned long int num,
       ASC_PANIC("Attempt to expand previously expanded array.\n");
     }
   } else {			/* not there yet recurse on each child */
-    register unsigned long c,len;
-    register struct ArrayChild *child;
-    register struct ArrayInstance *ptr;
+    unsigned long c,len;
+    struct ArrayChild *child;
+    struct ArrayInstance *ptr;
     ptr = ARY_INST(i);
     if (ptr->children==NULL){
       Asc_Panic(2, NULL,
@@ -892,7 +892,7 @@ int RealCmpArrayInsts(struct ArrayInstance *a1, struct ArrayInstance *a2)
 {
   unsigned long c,len;
   struct gl_list_t *cl1, *cl2;
-  register struct ArrayChild *ac1, *ac2;
+  struct ArrayChild *ac1, *ac2;
   int cmp;
 
   if (a1==a2) {

--- a/ascend/compiler/ascCompiler.c
+++ b/ascend/compiler/ascCompiler.c
@@ -113,8 +113,8 @@ void InterfaceNotifyProc(char *ptr, struct Instance *old, struct Instance *new)
   UNUSED_PARAMETER(new);
   (void)old;
 #if 0 /* is, officially, no big deal. baa .*/
-  register unsigned long c,len;
-  register struct Instance *sptr;
+  unsigned long c,len;
+  struct Instance *sptr;
   len = gl_length(g_simulation_list);
   for(c=len;c>=1;c--) {
     sptr = (struct Instance *)gl_fetch(g_simulation_list,c);

--- a/ascend/compiler/atomsize.c
+++ b/ascend/compiler/atomsize.c
@@ -48,7 +48,7 @@
 static unsigned long ChildMemory(unsigned long int count,
                                  CONST struct ChildDesc *cdesc)
 {
-  register unsigned long result;
+  unsigned long result;
   result = NextHighestEven(count)*sizeof(struct Instance *);
   while(count) {
     switch(ChildDescType(GetChildArrayElement(cdesc,count))) {

--- a/ascend/compiler/child.c
+++ b/ascend/compiler/child.c
@@ -143,7 +143,7 @@ ChildListPtr CreateChildList(struct gl_list_t *l)
 {
   struct ChildListEntry *old;
   struct ChildListStructure *result;
-  register unsigned long c,length;
+  unsigned long c,length;
   assert(l!=NULL);
 
   length = gl_length(l);
@@ -249,10 +249,10 @@ ChildListPtr AppendChildList(ChildListPtr cl,
 {
   struct ChildListStructure *result;
   struct ChildListEntry *cle, *gle;
-  register unsigned long length,cln,gln;
-  register unsigned long clength;
+  unsigned long length,cln,gln;
+  unsigned long clength;
 #ifndef NDEBUG
-  register unsigned long totlen;
+  unsigned long totlen;
 #endif
   assert(l!=NULL);
   assert(cl!=NULL);

--- a/ascend/compiler/childdef.c
+++ b/ascend/compiler/childdef.c
@@ -433,8 +433,8 @@ void MakeStatementPass(struct gl_list_t *l,
 		       struct BitList *blist,
 		       struct BitList *inited)
 {
-  register unsigned long c,len;
-  register struct Statement *stat;
+  unsigned long c,len;
+  struct Statement *stat;
   len = gl_length(l);
   c = FirstNonZeroBit(blist);
   while(c<len){
@@ -463,7 +463,7 @@ void MakeStatementPass(struct gl_list_t *l,
 static
 unsigned long BitCount(struct BitList *blist)
 {
-  register unsigned long result=0,c,len;
+  unsigned long result=0,c,len;
   len = BLength(blist);
   for(c=FirstNonZeroBit(blist); c < len;c++)
     if (ReadBit(blist,c)) result++;
@@ -500,8 +500,8 @@ struct ChildDesc *MakeChildDesc(symchar *name,
 				struct StatementList *sl,
 				ChildListPtr clist)
 {
-  register unsigned num_children;
-  register struct ChildDesc *result;
+  unsigned num_children;
+  struct ChildDesc *result;
   num_children = ChildListLen(clist);
   if (num_children) {
     result = CreateChildDescArray(num_children);

--- a/ascend/compiler/childinfo.c
+++ b/ascend/compiler/childinfo.c
@@ -57,7 +57,7 @@ struct ChildDesc *CreateChildDescArray(unsigned long int l){
 
 struct ChildDesc *CreateEmptyChildDescArray(void)
 {
-  register struct ChildDesc *cda = NULL;
+  struct ChildDesc *cda = NULL;
   cda = ASC_NEW_CLEAR(struct ChildDesc);
   assert(cda != NULL);
   cda->t = bad_child;

--- a/ascend/compiler/commands.c
+++ b/ascend/compiler/commands.c
@@ -103,7 +103,7 @@ extern unsigned long NumberCommands(void)
 
 extern CONST char *CommandName(unsigned long int u)
 {
-  register struct command_t *ptr;
+  struct command_t *ptr;
   ptr = (struct command_t *)gl_fetch(global_command_list,u);
   return ptr->str;
 }
@@ -111,7 +111,7 @@ extern CONST char *CommandName(unsigned long int u)
 
 extern CONST char *CommandHelp(unsigned long int u)
 {
-  register struct command_t *ptr;
+  struct command_t *ptr;
   ptr = (struct command_t *)gl_fetch(global_command_list,u);
   return ptr->help;
 }
@@ -119,7 +119,7 @@ extern CONST char *CommandHelp(unsigned long int u)
 
 extern void CommandFunc(unsigned long int u, InterfaceCommandF *func)
 {
-  register struct command_t *ptr;
+  struct command_t *ptr;
   ptr = (struct command_t *)gl_fetch(global_command_list,u);
   *func = ptr->func;
 }
@@ -127,7 +127,7 @@ extern void CommandFunc(unsigned long int u, InterfaceCommandF *func)
 
 extern int CommandTerminate(unsigned long int u)
 {
-  register struct command_t *ptr;
+  struct command_t *ptr;
   ptr = (struct command_t *)gl_fetch(global_command_list,u);
   return ptr->terminate;
 }
@@ -135,7 +135,7 @@ extern int CommandTerminate(unsigned long int u)
 
 extern int CommandNumArgs(unsigned long int u)
 {
-  register struct command_t *ptr;
+  struct command_t *ptr;
   ptr = (struct command_t *)gl_fetch(global_command_list,u);
   return ptr->num_args;
 }
@@ -143,7 +143,7 @@ extern int CommandNumArgs(unsigned long int u)
 
 extern enum arg_type CommandArgument(unsigned long int u, int i)
 {
-  register struct command_t *ptr;
+  struct command_t *ptr;
   ptr = (struct command_t *)gl_fetch(global_command_list,u);
   return ptr->args[i];
 }
@@ -151,7 +151,7 @@ extern enum arg_type CommandArgument(unsigned long int u, int i)
 
 extern void CommandArgsPrint(FILE *fp, unsigned long int u)
 {
-  register struct command_t *ptr;
+  struct command_t *ptr;
   int i;
   ptr = (struct command_t *)gl_fetch(global_command_list,u);
   FPRINTF(fp,"%s",ptr->str);
@@ -185,8 +185,8 @@ extern void CommandArgsPrint(FILE *fp, unsigned long int u)
 
 
 static
-int mycmp(register CONST char *str1,
-	  register CONST char *str2)
+int mycmp(CONST char *str1,
+	  CONST char *str2)
 {
   while(*str1 != '\0') {
     if (*str1 < *str2) return -1;
@@ -204,10 +204,10 @@ int mycmp(register CONST char *str1,
  */
 static
 unsigned long FindGLB(CONST char *str, int place,
-		      register unsigned long int lower,
-		      register unsigned long int upper)
+		      unsigned long int lower,
+		      unsigned long int upper)
 {
-  register struct command_t *ptr;
+  struct command_t *ptr;
   unsigned long search;
   str += place;
   while (lower <= upper){
@@ -234,10 +234,10 @@ unsigned long FindGLB(CONST char *str, int place,
  */
 static
 unsigned long FindLUB(CONST char *str, int place,
-		      register unsigned long int lower,
-		      register unsigned long int upper)
+		      unsigned long int lower,
+		      unsigned long int upper)
 {
-  register struct command_t *ptr;
+  struct command_t *ptr;
   unsigned long search;
   str += place;
   while (lower <= upper){
@@ -261,7 +261,7 @@ unsigned long FindLUB(CONST char *str, int place,
 extern void LimitCommand(unsigned long int *lower, unsigned long int *upper,
                          CONST char *str, int place)
 {
-  register struct command_t *ptr;
+  struct command_t *ptr;
   if (*lower > *upper) return;
   if (*lower == *upper){
     ptr = (struct command_t *)gl_fetch(global_command_list,*lower);
@@ -276,10 +276,10 @@ extern void LimitCommand(unsigned long int *lower, unsigned long int *upper,
 
 
 static
-int NumberMatch(register CONST char *str1,
-		register CONST char *str2, int max)
+int NumberMatch(CONST char *str1,
+		CONST char *str2, int max)
 {
-  register int c=0;
+  int c=0;
   while((c<max)&&(*str1 != '\0')&&(*str1 == *str2)){
     str1++;
     str2++;
@@ -292,10 +292,10 @@ int NumberMatch(register CONST char *str1,
 extern void CompleteCommand(unsigned long int lower, unsigned long int upper,
                             char *str, int *place)
 {
-  register CONST char *cpy;
+  CONST char *cpy;
   int count;
   unsigned long pos;
-  register struct command_t *ptr;
+  struct command_t *ptr;
   ptr = (struct command_t *)gl_fetch(global_command_list,lower);
   cpy = ptr->str;
   count = (int)strlen(cpy);
@@ -312,7 +312,7 @@ extern void CompleteCommand(unsigned long int lower, unsigned long int upper,
 extern unsigned long int FindCommand(CONST char *s)
 {
   struct gl_list_t *clist;
-  register struct command_t *ptr;
+  struct command_t *ptr;
   unsigned long pos,len;
   clist = global_command_list;
   if (clist == NULL || s==NULL) return 0;

--- a/ascend/compiler/copyinst.c
+++ b/ascend/compiler/copyinst.c
@@ -113,10 +113,10 @@ struct Instance *ShortCutProtoInstance(struct TypeDescription *type)
   Copy Instance code.
 \*********************************************************************/
 
-void CheckChildCopies(register unsigned long int num,
-		      register struct Instance **clist)
+void CheckChildCopies(unsigned long int num,
+		      struct Instance **clist)
 {
-  register unsigned long c;
+  unsigned long c;
   for(c=0;c<num;c++) {
     if ((clist[c]->t==SET_INST)&&(S_INST(clist[c])->list!=NULL)) {
       S_INST(clist[c])->list = CopySet(S_INST(clist[c])->list);
@@ -147,8 +147,8 @@ static
 struct Instance *CopyReal(CONST struct Instance *i)
 {
   if (IsAtomicInstance(i)) {
-    register struct RealAtomInstance *src,*result;
-    register unsigned long size;
+  struct RealAtomInstance *src,*result;
+  unsigned long size;
     AssertMemory(i);
     src = RA_INST(i);
     size = GetByteSize(src->desc);
@@ -166,8 +166,8 @@ struct Instance *CopyReal(CONST struct Instance *i)
     AssertMemory(result);
     return INST(result);
   } else {
-    register struct RealConstantInstance *src,*result;
-    register unsigned long size;
+  struct RealConstantInstance *src,*result;
+  unsigned long size;
     AssertMemory(i);
     src = RC_INST(i);
     size = GetByteSize(src->desc);
@@ -188,8 +188,8 @@ static
 struct Instance *CopyInteger(CONST struct Instance *i)
 {
   if (IsAtomicInstance(i)) {
-    register struct IntegerAtomInstance *src,*result;
-    register unsigned long size;
+  struct IntegerAtomInstance *src,*result;
+  unsigned long size;
 
     AssertMemory(i);
     src = IA_INST(i);
@@ -208,8 +208,8 @@ struct Instance *CopyInteger(CONST struct Instance *i)
     AssertMemory(result);
     return INST(result);
   } else {
-    register struct IntegerConstantInstance *src,*result;
-    register unsigned long size;
+  struct IntegerConstantInstance *src,*result;
+  unsigned long size;
 
     AssertMemory(i);
     src = IC_INST(i);
@@ -232,8 +232,8 @@ static
 struct Instance *CopyBoolean(CONST struct Instance *i)
 {
   if (IsAtomicInstance(i)) {
-    register struct BooleanAtomInstance *src,*result;
-    register unsigned long size;
+  struct BooleanAtomInstance *src,*result;
+  unsigned long size;
     AssertMemory(i);
     src = BA_INST(i);
     size = GetByteSize(src->desc);
@@ -253,8 +253,8 @@ struct Instance *CopyBoolean(CONST struct Instance *i)
     AssertMemory(result);
     return INST(result);
   } else {
-    register struct BooleanConstantInstance *src,*result;
-    register unsigned long size;
+  struct BooleanConstantInstance *src,*result;
+  unsigned long size;
     AssertMemory(i);
     src = BC_INST(i);
     size = GetByteSize(src->desc);
@@ -272,8 +272,8 @@ struct Instance *CopyBoolean(CONST struct Instance *i)
 static
 struct Instance *CopySetInst(CONST struct Instance *i)
 {
-  register struct SetAtomInstance *src, *result;
-  register unsigned long size;
+  struct SetAtomInstance *src, *result;
+  unsigned long size;
   AssertMemory(i);
   src = SA_INST(i);
   size = GetByteSize(src->desc);
@@ -300,8 +300,8 @@ static
 struct Instance *CopySymbolInst(CONST struct Instance *i)
 {
   if (IsAtomicInstance(i)) {
-    register struct SymbolAtomInstance *src,*result;
-    register unsigned long size;
+  struct SymbolAtomInstance *src,*result;
+  unsigned long size;
     AssertMemory(i);
     src = SYMA_INST(i);
     size = GetByteSize(src->desc);
@@ -319,8 +319,8 @@ struct Instance *CopySymbolInst(CONST struct Instance *i)
     AssertMemory(result);
     return INST(result);
   } else {
-    register struct SymbolConstantInstance *src,*result;
-    register unsigned long size;
+  struct SymbolConstantInstance *src,*result;
+  unsigned long size;
     AssertMemory(i);
     src = SYMC_INST(i);
     size = GetByteSize(src->desc);
@@ -338,8 +338,8 @@ struct Instance *CopySymbolInst(CONST struct Instance *i)
 static
 struct Instance *CopyRelationInst(CONST struct Instance *i)
 {
-  register struct RelationInstance *src,*result;
-  register unsigned long size;
+  struct RelationInstance *src,*result;
+  unsigned long size;
   AssertMemory(i);
   src = RELN_INST(i);
   size = GetByteSize(src->desc);
@@ -368,8 +368,8 @@ struct Instance *CopyRelationInst(CONST struct Instance *i)
 static
 struct Instance *CopyLogRelInst(CONST struct Instance *i)
 {
-  register struct LogRelInstance *src,*result;
-  register unsigned long size;
+  struct LogRelInstance *src,*result;
+  unsigned long size;
   AssertMemory(i);
   src = LRELN_INST(i);
   size = GetByteSize(src->desc);
@@ -398,8 +398,8 @@ struct Instance *CopyLogRelInst(CONST struct Instance *i)
 static
 struct Instance *CopyWhenInst(CONST struct Instance *i)
 {
-  register struct WhenInstance *src,*result;
-  register unsigned long size;
+  struct WhenInstance *src,*result;
+  unsigned long size;
   AssertMemory(i);
   src = W_INST(i);
   size = sizeof(struct WhenInstance);
@@ -423,9 +423,9 @@ struct Instance *CopyWhenInst(CONST struct Instance *i)
 static
 struct Instance *CopyModel(CONST struct Instance *i)
 {
-  register struct ModelInstance *mod,*result;
-  register unsigned long num_children;
-  register struct TypeDescription *type;
+  struct ModelInstance *mod,*result;
+  unsigned long num_children;
+  struct TypeDescription *type;
   AssertMemory(i);
   mod = MOD_INST(i);
   type = mod->desc;
@@ -452,9 +452,9 @@ struct Instance *CopyModel(CONST struct Instance *i)
 
 static struct gl_list_t *CopyArrayChildPtrs(struct gl_list_t *list)
 {
-  register struct gl_list_t *result;
-  register unsigned long length,c;
-  register struct ArrayChild *new,*src;
+  struct gl_list_t *result;
+  unsigned long length,c;
+  struct ArrayChild *new,*src;
   if (list!=NULL){
     length = gl_length(list);
     if (length) {
@@ -478,7 +478,7 @@ static struct gl_list_t *CopyArrayChildPtrs(struct gl_list_t *list)
 
 static struct Instance *CopyArray(CONST struct Instance *i)
 {
-  register struct ArrayInstance *ary,*result;
+  struct ArrayInstance *ary,*result;
   AssertMemory(i);
   ary = ARY_INST(i);
   result = ARY_INST(ascmalloc(sizeof(struct ArrayInstance)));

--- a/ascend/compiler/createinst.c
+++ b/ascend/compiler/createinst.c
@@ -74,8 +74,8 @@
 #include "instmacro.h"
 #include "instquery.h"
 
-void ZeroNewChildrenEntries(register struct Instance **child_ary,
-			    register unsigned long int num)
+void ZeroNewChildrenEntries(struct Instance **child_ary,
+			    unsigned long int num)
 {
   /* initialize all the children pointers to NULL */
   while(num--) {
@@ -93,9 +93,9 @@ void ZeroNewChildrenEntries(register struct Instance **child_ary,
  */
 struct Instance *CreateModelInstance(struct TypeDescription *type)
 {
-  register struct ModelInstance *result, *proto;
-  register unsigned long num_children;
-  register CONST struct StatementList *stats;
+  struct ModelInstance *result, *proto;
+  unsigned long num_children;
+  CONST struct StatementList *stats;
   proto = MOD_INST(LookupPrototype(GetName(type)));
   if (proto==NULL) {
     CopyTypeDesc(type);
@@ -158,7 +158,7 @@ struct Instance *CreateDummyInstance(struct TypeDescription *gdt)
 struct Instance *CreateSimulationInstance(struct TypeDescription *type,
 					  symchar *name)
 {
-  register struct SimulationInstance *result;
+  struct SimulationInstance *result;
   unsigned num_children;
   /* unsigned int size; */
 
@@ -244,7 +244,7 @@ static void MakeAtomChildren(unsigned long int nc, /* number of children */
 		      CONST struct ChildDesc *childd) /* children */
 						      /* descriptions */
 {
-  register unsigned long c=1;
+  unsigned long c=1;
   struct ChildDesc cd;
   while(c<=nc) {
     AssertContainedIn(parent,base);
@@ -313,8 +313,8 @@ static void MakeAtomChildren(unsigned long int nc, /* number of children */
 struct Instance *CreateRealInstance(struct TypeDescription *type){
 
   if (BaseTypeIsAtomic(type)) {
-    register struct RealAtomInstance *result;
-    register unsigned long num_children;
+  struct RealAtomInstance *result;
+  unsigned long num_children;
 
     if ((result=RA_INST(LookupPrototype(GetName(type))))==NULL) {
       CopyTypeDesc(type);
@@ -372,7 +372,7 @@ struct Instance *CreateRealInstance(struct TypeDescription *type){
     }
   } else {
     /* create constant */
-    register struct RealConstantInstance *result;
+  struct RealConstantInstance *result;
     if((result=RC_INST(LookupPrototype(GetName(type))))==NULL){
       CopyTypeDesc(type);
       result = RC_INST(ascmalloc(GetByteSize(type)));
@@ -408,8 +408,8 @@ struct Instance *CreateRealInstance(struct TypeDescription *type){
 struct Instance *CreateIntegerInstance(struct TypeDescription *type)
 {
   if (BaseTypeIsAtomic(type)) {
-    register struct IntegerAtomInstance *result;
-    register unsigned long num_children;
+  struct IntegerAtomInstance *result;
+  unsigned long num_children;
 
     if ((result=IA_INST(LookupPrototype(GetName(type))))==NULL) {
       CopyTypeDesc(type);
@@ -450,7 +450,7 @@ struct Instance *CreateIntegerInstance(struct TypeDescription *type)
       return CopyInstance(INST(result));
     }
   } else {
-    register struct IntegerConstantInstance *result;
+  struct IntegerConstantInstance *result;
 
     if ((result=IC_INST(LookupPrototype(GetName(type))))==NULL) {
       CopyTypeDesc(type);
@@ -487,8 +487,8 @@ struct Instance *CreateIntegerInstance(struct TypeDescription *type)
 struct Instance *CreateBooleanInstance(struct TypeDescription *type)
 {
   if (BaseTypeIsAtomic(type)) {
-    register struct BooleanAtomInstance *result;
-    register unsigned long num_children;
+  struct BooleanAtomInstance *result;
+  unsigned long num_children;
 
     if ((result=BA_INST(LookupPrototype(GetName(type))))==NULL) {
       CopyTypeDesc(type);
@@ -531,7 +531,7 @@ struct Instance *CreateBooleanInstance(struct TypeDescription *type)
       return CopyInstance(INST(result));
     }
   } else {
-    register struct BooleanConstantInstance *result;
+  struct BooleanConstantInstance *result;
 
     if ((result=BC_INST(LookupPrototype(GetName(type))))==NULL) {
       CopyTypeDesc(type);
@@ -567,8 +567,8 @@ struct Instance *CreateBooleanInstance(struct TypeDescription *type)
 struct Instance *CreateSetInstance(struct TypeDescription *type, int intset)
 {
   if (BaseTypeIsAtomic(type)) {
-    register struct SetAtomInstance *result;
-    register unsigned long num_children;
+  struct SetAtomInstance *result;
+  unsigned long num_children;
 
     if ((result=SA_INST(LookupPrototype(GetName(type))))==NULL) {
       CopyTypeDesc(type);
@@ -610,8 +610,8 @@ struct Instance *CreateSetInstance(struct TypeDescription *type, int intset)
 struct Instance *CreateSymbolInstance(struct TypeDescription *type)
 {
   if (BaseTypeIsAtomic(type)) {
-    register struct SymbolAtomInstance *result;
-    register unsigned long num_children;
+  struct SymbolAtomInstance *result;
+  unsigned long num_children;
 
     if ((result=SYMA_INST(LookupPrototype(GetName(type))))==NULL){
       CopyTypeDesc(type);
@@ -649,7 +649,7 @@ struct Instance *CreateSymbolInstance(struct TypeDescription *type)
       return CopyInstance(INST(result));
     }
   } else {
-    register struct SymbolConstantInstance *result;
+  struct SymbolConstantInstance *result;
 
     if ((result=SYMC_INST(LookupPrototype(GetName(type))))==NULL){
       CopyTypeDesc(type);
@@ -686,8 +686,8 @@ struct Instance *CreateSymbolInstance(struct TypeDescription *type)
 struct Instance *CreateRelationInstance(struct TypeDescription *type,
 					enum Expr_enum reltype)
 {
-  register struct RelationInstance *result;
-  register unsigned long num_children;
+  struct RelationInstance *result;
+  unsigned long num_children;
   /* ERROR_REPORTER_DEBUG("Entered CreateRelationInstance\n"); */
 
   if ((result=RELN_INST(LookupPrototype(GetName(type))))==NULL){
@@ -731,8 +731,8 @@ struct Instance *CreateRelationInstance(struct TypeDescription *type,
 
 struct Instance *CreateLogRelInstance(struct TypeDescription *type)
 {
-  register struct LogRelInstance *result;
-  register unsigned long num_children;
+  struct LogRelInstance *result;
+  unsigned long num_children;
   if ((result=LRELN_INST(LookupPrototype(GetName(type))))==NULL){
     CopyTypeDesc(type);
     num_children = ChildListLen(GetChildList(type));
@@ -768,7 +768,7 @@ struct Instance *CreateLogRelInstance(struct TypeDescription *type)
 
 struct Instance *CreateWhenInstance(struct TypeDescription *type)
 {
-  register struct WhenInstance *result;
+  struct WhenInstance *result;
   if ((result=W_INST(LookupPrototype(GetName(type))))==NULL){
     CopyTypeDesc(type);
     result = W_INST(ascmalloc((unsigned)sizeof(struct WhenInstance)));

--- a/ascend/compiler/destroyinst.c
+++ b/ascend/compiler/destroyinst.c
@@ -158,7 +158,7 @@ static void DeleteIPtr(struct Instance *i){
 static int RemoveParentReferences(
 	struct Instance *inst, struct Instance *parent
 ){
-  register unsigned long c,pos,length;
+  unsigned long c,pos,length;
   AssertMemory(inst);
   if(parent!=NULL){
     AssertMemory(parent);
@@ -195,7 +195,7 @@ static int RemoveParentReferences(
 }
 
 static void RemoveFromClique(struct Instance *inst){
-  register struct Instance *i,*hold;
+  struct Instance *i,*hold;
   AssertMemory(inst);
   if ((hold=i=NextCliqueMember(inst))==inst)
     return;
@@ -254,7 +254,7 @@ static void DeleteArrayChild(struct ArrayChild *acp, struct Instance *parent){
 static void RemoveRelationLinks(struct Instance *i){
   struct gl_list_t *list = RA_INST(i)->relations;
   if(NULL==list)return;
-  register unsigned long c,length;
+  unsigned long c,length;
   assert(list!=NULL);
   length = gl_length(list);
   for(c=1;c<=length;c++){
@@ -276,7 +276,7 @@ static void RemoveRelationLinks(struct Instance *i){
 static
 void RemoveLogRelLinks(struct Instance *i, struct gl_list_t *list)
 {
-  register unsigned long c,length;
+  unsigned long c,length;
   assert(list!=NULL);
   length = gl_length(list);
   for(c=1;c<=length;c++) {
@@ -289,7 +289,7 @@ void RemoveLogRelLinks(struct Instance *i, struct gl_list_t *list)
 static
 void RemoveWhenLinks(struct Instance *i, struct gl_list_t *list)
 {
-  register unsigned long c,length;
+  unsigned long c,length;
   assert(list!=NULL);
   length = gl_length(list);
   for(c=1;c<=length;c++) {
@@ -299,7 +299,7 @@ void RemoveWhenLinks(struct Instance *i, struct gl_list_t *list)
 }
 
 static void DestroyAtomChildren(
-	register struct Instance **i, register unsigned long int nc
+  struct Instance **i, unsigned long int nc
 ){
   while(nc-- > 0){
     AssertMemory(i);
@@ -318,8 +318,8 @@ static void DestroyAtomChildren(
 	to the object.
 */
 static void DestroyInstanceParts(struct Instance *i){
-  register unsigned long c,length;
-  register struct gl_list_t *l;
+  unsigned long c,length;
+  struct gl_list_t *l;
   struct Instance *child;
   AssertMemory(i);
   switch(i->t) {

--- a/ascend/compiler/dimen.c
+++ b/ascend/compiler/dimen.c
@@ -236,8 +236,8 @@ int SameDimen(const dim_type *d1, const dim_type *d2){
 
 
 int CmpDimen(const dim_type *d1, const dim_type *d2){
-	register unsigned c;
-	register int i;
+	unsigned c;
+	int i;
 	assert(d1!=NULL);
 	assert(d2!=NULL);
 	if (WILD(d1)) {
@@ -264,7 +264,7 @@ int CmpDimen(const dim_type *d1, const dim_type *d2){
 
 
 void ClearDimensions(dim_type *d){
-  register unsigned c;
+  unsigned c;
   struct fraction f;
   assert(d!=NULL);
   f = CreateFraction((FRACPART)0,(FRACPART)1);
@@ -293,8 +293,8 @@ const dim_type *WildDimension(void){
 
 
 static
-dim_type *CopyDimen(register const dim_type *d){
-  register dim_type *result;
+dim_type *CopyDimen(const dim_type *d){
+  dim_type *result;
   assert(d!=NULL);
   result = ASC_NEW(dim_type);
   ascbcopy((char *)d,(char *)result,sizeof(dim_type));
@@ -304,8 +304,8 @@ dim_type *CopyDimen(register const dim_type *d){
 
 
 const dim_type *FindOrAddDimen(const dim_type *d){
-  register unsigned long place;
-  register dim_type *result;
+  unsigned long place;
+  dim_type *result;
   if ((place=gl_search(g_dimen_list,d,(CmpFunc)CmpDimen))!=0){
     result = gl_fetch(g_dimen_list,place);
   }
@@ -319,7 +319,7 @@ const dim_type *FindOrAddDimen(const dim_type *d){
 
 
 dim_type AddDimensions(const dim_type *d1, const dim_type *d2){
-  register unsigned c;
+  unsigned c;
   dim_type result;
   ClearDimensions(&result);
   if (WILD(d1)||WILD(d2)) {
@@ -335,7 +335,7 @@ dim_type AddDimensions(const dim_type *d1, const dim_type *d2){
 
 
 const dim_type *SumDimensions(const dim_type *d1, const dim_type *d2,int check){
-  register unsigned c;
+  unsigned c;
   dim_type result;
   if (check && (FractionalDimension(d1) || FractionalDimension(d2)) ) {
     return NULL;
@@ -354,7 +354,7 @@ const dim_type *SumDimensions(const dim_type *d1, const dim_type *d2,int check){
 
 
 dim_type SubDimensions(const dim_type *d1, const dim_type *d2){
-  register unsigned c;
+  unsigned c;
   dim_type result;
   ClearDimensions(&result);
   if (WILD(d1)||WILD(d2)) {
@@ -372,7 +372,7 @@ const dim_type *DiffDimensions(const dim_type *d1,
                                const dim_type *d2,
                                int check)
 {
-  register unsigned c;
+  unsigned c;
   dim_type result;
   if (check && (FractionalDimension(d1) || FractionalDimension(d2)) ){
     return NULL;
@@ -392,7 +392,7 @@ const dim_type *DiffDimensions(const dim_type *d1,
 
 dim_type ScaleDimensions(const dim_type *dim, struct fraction frac){
   dim_type result;
-  register unsigned c;
+  unsigned c;
   result = *dim;
   if (result.wild & DIM_WILD) return result;
   for(c=0;c<NUM_DIMENS;c++) {
@@ -441,7 +441,7 @@ ASC_DLLSPEC void PrintDimenMessage(const char *message
 
 
 void DumpDimens(FILE *file){
-  register unsigned long c,len;
+  unsigned long c,len;
   len = gl_length(g_dimen_list);
   FPRINTF(file,"Dimensions dump\n");
   for(c=1;c<=len;c++) {

--- a/ascend/compiler/dump.c
+++ b/ascend/compiler/dump.c
@@ -63,7 +63,7 @@ unsigned long g_dump_type_count,g_dump_inst_count;
 
 void InitDump(void)
 {
-  register unsigned c;
+  unsigned c;
   for(c=0;c<DUMPHASHSIZE;g_dump_ht[c++]=NULL);
   g_dump_type_count = 0;
   g_dump_inst_count = 0;
@@ -71,10 +71,10 @@ void InitDump(void)
 
 void EmptyTrash(void)
 {
-  register unsigned c;
-  register unsigned long i,len;
-  register struct DumpRec *p,*next;
-  register struct gl_list_t *l;
+  unsigned c;
+  unsigned long i,len;
+  struct DumpRec *p,*next;
+  struct gl_list_t *l;
   if (g_dump_inst_count==0) return;
   for(c=0;c<DUMPHASHSIZE;c++) {
     p = g_dump_ht[c];
@@ -98,10 +98,10 @@ void EmptyTrash(void)
 
 void TendTrash(void)
 {
-  register unsigned c;
-  register unsigned long i;
-  register struct DumpRec *p;
-  register struct gl_list_t *l;
+  unsigned c;
+  unsigned long i;
+  struct DumpRec *p;
+  struct gl_list_t *l;
   if (g_dump_inst_count <= MESSYTHRESH) return;
   for(c=0;c<DUMPHASHSIZE;c++) {
     p = g_dump_ht[c];
@@ -120,10 +120,10 @@ void TendTrash(void)
 
 void TrashType(symchar *str)
 {
-  register unsigned long c,len,bucket;
-  register struct DumpRec *p,*prev;
-  register struct gl_list_t *l;
-  register int cmp;
+  unsigned long c,len,bucket;
+  struct DumpRec *p,*prev;
+  struct gl_list_t *l;
+  int cmp;
   assert(AscFindSymbol(str)!=NULL);
   if (*(SCP(str)) == '\0') return;
   bucket = DUMPHASHINDEX(SCP(str));
@@ -157,11 +157,11 @@ void TrashType(symchar *str)
 
 struct Instance *FindInstance(symchar *str)
 {
-  register struct DumpRec *p,*prev;
-  register int cmp;
-  register struct gl_list_t *l;
-  register struct Instance *result;
-  register unsigned long bucket;
+  struct DumpRec *p,*prev;
+  int cmp;
+  struct gl_list_t *l;
+  struct Instance *result;
+  unsigned long bucket;
   if (*(SCP(str)) == '\0') return NULL;
   bucket = DUMPHASHINDEX(SCP(str));
   if ((p = g_dump_ht[bucket])==NULL) return NULL;
@@ -207,10 +207,10 @@ void AddInstance(struct Instance *i)
 
      /* add instance i to the trash dump */
 {
-  register struct DumpRec *p,*prev;
-  register symchar *type;
-  register int cmp;
-  register unsigned long bucket;
+  struct DumpRec *p,*prev;
+  symchar *type;
+  int cmp;
+  unsigned long bucket;
   type = InstanceType(i);
   if ((i==NULL)||(type==NULL)) return;
   bucket = DUMPHASHINDEX(SCP(type));

--- a/ascend/compiler/evaluate.c
+++ b/ascend/compiler/evaluate.c
@@ -179,7 +179,7 @@ static
 unsigned int ExprStackDepth(CONST struct Expr *ex,
 			    CONST struct Expr *stop)
 {
-  register unsigned int maxdepth=0,depth=0;
+  unsigned int maxdepth=0,depth=0;
   while (ex!=stop){
     AssertMemory(ex);
     switch(ExprType(ex)){
@@ -652,7 +652,7 @@ struct value_t EvaluateExpr(CONST struct Expr *expr, CONST struct Expr *stop,
 {
   struct value_t top,next;
   symchar *cptr;
-  register struct stack_t *stack;
+  struct stack_t *stack;
   IVAL(top);
   IVAL(next);
   if (ContainsSuchThat(expr,stop)!=NULL) {

--- a/ascend/compiler/exprs.c
+++ b/ascend/compiler/exprs.c
@@ -153,7 +153,7 @@ void exprs_report_pool(void){
 
 struct Expr *CreateVarExpr(struct Name *n)
 {
-  register struct Expr *result;
+  struct Expr *result;
   assert(n!=NULL);
   AssertMemory(n);
   EXPR_NEW(result,e_var);
@@ -174,7 +174,7 @@ void InitVarExpr(struct Expr *result,CONST struct Name *n)
 
 struct Expr *CreateOpExpr(enum Expr_enum t)
 {
-  register struct Expr *result;
+  struct Expr *result;
   assert((t!=e_var)&&(t!=e_func)&&(t!=e_int)&&(t!=e_real)&&(t!=e_zero));
   EXPR_NEW(result,t);
 #if EXPRSUSESPOOL
@@ -188,7 +188,7 @@ struct Expr *CreateOpExpr(enum Expr_enum t)
 struct Expr *CreateSatisfiedExpr(struct Name *n, double tol,
                                  CONST dim_type *dims)
 {
-  register struct Expr *result;
+  struct Expr *result;
   EXPR_NEW(result,e_satisfied);
   result->v.se.sen =  n;
   result->v.se.ser.rvalue = tol;
@@ -199,7 +199,7 @@ struct Expr *CreateSatisfiedExpr(struct Name *n, double tol,
 
 struct Expr *CreateFuncExpr(CONST struct Func *f)
 {
-  register struct Expr *result;
+  struct Expr *result;
   EXPR_NEW(result,e_func);
   result->v.fptr = f;
   EXPR_CHECK_MEMORY(result);
@@ -208,7 +208,7 @@ struct Expr *CreateFuncExpr(CONST struct Func *f)
 
 struct Expr *CreateIntExpr(long int i)
 {
-  register struct Expr *result;
+  struct Expr *result;
   EXPR_NEW(result,e_int);
   result->v.ivalue = i;
   EXPR_CHECK_MEMORY(result);
@@ -217,7 +217,7 @@ struct Expr *CreateIntExpr(long int i)
 
 struct Expr *CreateRealExpr(double r, CONST dim_type *dims)
 {
-  register struct Expr *result;
+  struct Expr *result;
   EXPR_NEW(result,e_real);
   result->v.r.rvalue = r;
   result->v.r.dimensions = dims;
@@ -227,7 +227,7 @@ struct Expr *CreateRealExpr(double r, CONST dim_type *dims)
 
 struct Expr *CreateTrueExpr(void)
 {
-  register struct Expr *result;
+  struct Expr *result;
   EXPR_NEW(result,e_boolean);
   result->v.bvalue = 1;
   EXPR_CHECK_MEMORY(result);
@@ -236,7 +236,7 @@ struct Expr *CreateTrueExpr(void)
 
 struct Expr *CreateFalseExpr(void)
 {
-  register struct Expr *result;
+  struct Expr *result;
   EXPR_NEW(result,e_boolean);
   result->v.bvalue = 0;
   EXPR_CHECK_MEMORY(result);
@@ -245,7 +245,7 @@ struct Expr *CreateFalseExpr(void)
 
 struct Expr *CreateAnyExpr(void)
 {
-  register struct Expr *result;
+  struct Expr *result;
   EXPR_NEW(result,e_boolean);
   result->v.bvalue = 2;
   EXPR_CHECK_MEMORY(result);
@@ -254,7 +254,7 @@ struct Expr *CreateAnyExpr(void)
 
 struct Expr *CreateSetExpr(struct Set *set)
 {
-  register struct Expr *result;
+  struct Expr *result;
   EXPR_NEW(result,e_set);
   result->v.s = set;
   EXPR_CHECK_MEMORY(result);
@@ -264,7 +264,7 @@ struct Expr *CreateSetExpr(struct Set *set)
 
 struct Expr *CreateSymbolExpr(symchar *sym)
 {
-  register struct Expr *result;
+  struct Expr *result;
   assert(AscFindSymbol(sym)!=NULL);
   EXPR_NEW(result,e_symbol);
   result->v.sym_ptr = sym;
@@ -274,7 +274,7 @@ struct Expr *CreateSymbolExpr(symchar *sym)
 
 struct Expr *CreateQStringExpr(CONST char *qstr)
 {
-  register struct Expr *result;
+  struct Expr *result;
   EXPR_NEW(result,e_qstring);
   result->v.sym_ptr = (symchar *)qstr; /* qstr really not symbol */
   EXPR_CHECK_MEMORY(result);
@@ -283,7 +283,7 @@ struct Expr *CreateQStringExpr(CONST char *qstr)
 
 struct Expr *CreateBuiltin(enum Expr_enum t, struct Set *set)
 {
-  register struct Expr *result;
+  struct Expr *result;
   EXPR_NEW(result,t);
   result->v.s = set;
   EXPR_CHECK_MEMORY(result);
@@ -376,8 +376,8 @@ CONST dim_type *SatisfiedExprRDimensionsF(CONST struct Expr *e)
  */
 struct Expr *CopyExprList(CONST struct Expr *e)
 {
-  register struct Expr *result, *p;
-  register CONST struct Expr *ep;
+  struct Expr *result, *p;
+  CONST struct Expr *ep;
   if (e==NULL) return NULL;
   AssertMemory(e);
   ep = e;
@@ -494,7 +494,7 @@ struct Expr *CopyExprList(CONST struct Expr *e)
 
 void DestroyExprList(struct Expr *e)
 {
-  register struct Expr *next,*ep;
+  struct Expr *next,*ep;
   ep = e;
   while(ep!=NULL) {
     AssertMemory(ep);
@@ -522,7 +522,7 @@ void DestroyExprList(struct Expr *e)
 
 struct Expr *JoinExprLists(struct Expr *e1, struct Expr *e2)
 {
-  register struct Expr *e;
+  struct Expr *e;
   if (e1 == NULL) return e2;
   AssertMemory(e1);
   e = e1;
@@ -536,7 +536,7 @@ struct Expr *JoinExprLists(struct Expr *e1, struct Expr *e2)
 
 unsigned long ExprListLength(CONST struct Expr *e)
 {
-  register CONST struct Expr *ptr;
+  CONST struct Expr *ptr;
   unsigned long len = 0L;
 
   AssertMemory(e);

--- a/ascend/compiler/forvars.c
+++ b/ascend/compiler/forvars.c
@@ -58,7 +58,7 @@ static struct for_var_t *ForVarMalloc(void)
 
 struct for_table_t *CreateForTable(void)
 {
-  register struct for_table_t *result;
+  struct for_table_t *result;
   result =gl_create(4L);
   AssertMemory(result);
   return result;
@@ -182,7 +182,7 @@ Routines to process for_var_t types.
 
 struct for_var_t *CreateForVar(symchar *name)
 {
-  register struct for_var_t *result;
+  struct for_var_t *result;
   assert(AscFindSymbol(name)!=NULL);
   result = FVMALLOC;
   result->t = f_untyped;

--- a/ascend/compiler/fractions.c
+++ b/ascend/compiler/fractions.c
@@ -30,7 +30,7 @@
 #include <ascend/general/platform.h>
 
 static
-short GCD(register int s1, register int s2)
+short GCD(int s1, int s2)
 /*
  *  Return the greatist common divisor of s1 and s2.  This is guarenteed
  *  to always work.  It can be proven to be correct.
@@ -57,7 +57,7 @@ short GCD(register int s1, register int s2)
 
 struct fraction Simplify(struct fraction f)
 {
-  register short s;
+  short s;
   if (f.denominator<0) {
     f.denominator = -f.denominator;
     f.numerator = -f.numerator;
@@ -127,7 +127,7 @@ struct fraction DivF(struct fraction f1, struct fraction f2)
 
 int CmpF(struct fraction f1, struct fraction f2)
 {
-  register FRACPART
+  FRACPART
     num1,
     num2;
   num1 = f1.numerator*f2.denominator;

--- a/ascend/compiler/func.c
+++ b/ascend/compiler/func.c
@@ -52,74 +52,74 @@ double g_lnm_epsilon = 1.0e-8;
 
 
 #if defined(__WIN32__) || defined(_WIN32) || defined(WIN32)
-double cbrt(register double d){
+double cbrt(double d){
   return pow(d,(double)0.3333333333333333333333);
 }
 #endif
 
-int ascnintF(register double d){
+int ascnintF(double d){
   return ((d)>=0.0 ? (int)floor((d) + 0.5) : -(int)floor(0.5 - (d)));
 }
 
 
-double dln(register double d){
+double dln(double d){
   return 1.0/d;
 }
 
-double dln2(register double d){
+double dln2(double d){
   return -1.0/(d*d);
 }
 
-double lnm(register double d){
+double lnm(double d){
   return (d>g_lnm_epsilon?log(d):d/g_lnm_epsilon + (log(g_lnm_epsilon) -1));
 
 }
 
-double dlnm(register double d){
+double dlnm(double d){
   return ( d>g_lnm_epsilon ? (double)1.0/d : 1/g_lnm_epsilon);
 }
 
-double dlnm2(register double d){
+double dlnm2(double d){
   return (d>g_lnm_epsilon ? (double)-1.0/(d*d) : (double)0.0);
 }
 
-double dlog10(register double d){
+double dlog10(double d){
   return M_LOG10E/d;
 }
 
-double dlog102(register double d){
+double dlog102(double d){
   return -M_LOG10E/(d*d);
 }
 
-double dcos(register double d){
+double dcos(double d){
   return -sin(d);
 }
 
-double dcos2(register double d){
+double dcos2(double d){
   return -cos(d);
 }
 
-double dtan(register double d){
-  register double c;
+double dtan(double d){
+  double c;
   c=cos(d);
   return 1.0/(c*c);
 }
 
-double dtan2(register double d){
-  register double c;
+double dtan2(double d){
+  double c;
   c=cos(d);
   return ldexp(tan(d)/(c*c),1);
 }
 
-double sqr(register double d){
+double sqr(double d){
   return d*d;
 }
 
-double dsqr(register double d){
+double dsqr(double d){
   return ldexp(d,1);
 }
 
-double dsqr2(register double d){
+double dsqr2(double d){
   (void)d;  /*  stop gcc whine about unused parameter */
   return 2.0;
 }
@@ -128,19 +128,19 @@ double hold(double d){
   return d;
 }
 
-double dsqrt(register double d){
+double dsqrt(double d){
   return 1.0/(ldexp(sqrt(d),1));
 }
 
-double dsqrt2(register double d){
+double dsqrt2(double d){
   return -1.0/ldexp(sqrt(d)*d,2);
 }
 
-double dfabs(register double d){
+double dfabs(double d){
   return ((d > 0.0) ? 1.0 : ((d<0.0 ) ? -1 : 0));
 }
 
-double dfabs2(register double d){
+double dfabs2(double d){
   (void)d;  /*  stop gcc whine about unused parameter */
   return 0.0;
 }
@@ -151,7 +151,7 @@ double dhold(double d){
 }
 
  /* The next 4 are new */
-double asc_ipow(register double d, int i) {
+double asc_ipow(double d, int i) {
   unsigned negative = 0;
   negative = (i<0);
   if (negative) i = (-i);
@@ -169,7 +169,7 @@ double asc_ipow(register double d, int i) {
   case 9: d = d*d*d*d*d*d*d*d*d; break;
   default:
     {
-      register double res;
+      double res;
       res = d;
       for (--i; i > 0; i--) res *= d;
       d = res;
@@ -211,110 +211,110 @@ double asc_d2ipow(double d, int i) {
 }
 
 
-double cube(register double d){
+double cube(double d){
   return d*d*d;
 }
-double dcube(register double d){
+double dcube(double d){
   return 3.0*d*d;
 }
-double dcube2(register double d){
+double dcube2(double d){
   return 6.0*d;
 }
 
-double dcbrt(register double d){
-  register double c;
+double dcbrt(double d){
+  double c;
   c=cbrt(d);
   return (double)0.3333333333333333/(c*c);
 }
 
-double dcbrt2(register double d){
-  register double c;
+double dcbrt2(double d){
+  double c;
   c=cbrt(d);
   return (double)-0.2222222222222222/pow(c,5.0);
 }
 
-double dasin(register double d){
+double dasin(double d){
   return 1.0/sqrt(1.0-d*d);
 }
 
-double dasin2(register double d){
-  register double c;
+double dasin2(double d){
+  double c;
   c=1.0-d*d;
   return d/(c*sqrt(c));
 }
 
-double dacos(register double d)
+double dacos(double d)
 {
   return -1.0/sqrt(1-d*d);
 }
 
-double dacos2(register double d){
-  register double c;
+double dacos2(double d){
+  double c;
   c=1.0-d*d;
   return -d/(c*sqrt(c));
 }
 
-double datan(register double d){
+double datan(double d){
   return 1.0/(1.0+d*d);
 }
 
-double datan2(register double d){
+double datan2(double d){
   return -2*d/sqr(1+d*d);
 }
 
 #ifdef HAVE_ERF
-double derf(register double d){
+double derf(double d){
   return ldexp(exp(-(d*d))/sqrt(M_PI),1);
 }
 
-double derf2(register double d)
+double derf2(double d)
 {
   return -ldexp(d*exp(-(d*d))/sqrt(M_PI),2);
 }
 #endif /* HAVE_ERF */
 
-double dtanh(register double d){
-  register double c;
+double dtanh(double d){
+  double c;
   c = cosh(d);
   c = 1/(c*c);
   return c;
 }
 
-double dtanh2(register double d){
-  register double c;
+double dtanh2(double d){
+  double c;
   c = cosh(d);
   return -ldexp(tanh(d),1)/(c*c);
 }
 
-double arcsinh(register double d){
+double arcsinh(double d){
   return log(d+sqrt(d*d+1.0));
 }
 
-double darcsinh(register double d){
+double darcsinh(double d){
   return 1.0/sqrt(d*d+1.0);
 }
 
-double darcsinh2(register double d){
-  register double c;
+double darcsinh2(double d){
+  double c;
   c=d*d+1.0;
   return -d/sqrt(c*c*c);
 }
 
-double arccosh(register double d){
+double arccosh(double d){
   return log(d+sqrt(d*d-1.0));
 }
 
-double darccosh(register double d){
+double darccosh(double d){
   return 1.0/sqrt(d*d-1.0);
 }
 
-double darccosh2(register double d){
-  register double c;
+double darccosh2(double d){
+  double c;
   c=d*d-1.0;
   return -d/sqrt(c*c*c);
 }
 
-double arctanh(register double d){
+double arctanh(double d){
   return  ldexp( log((d+1.0)/(1.0-d)) ,-1);
 /* an alternative, more expensive but perhaps less exception prone
 *  coding of arctanh is:
@@ -325,12 +325,12 @@ double arctanh(register double d){
 */
 }
 
-double darctanh(register double d){
+double darctanh(double d){
   return  1.0/(1-d*d);
 }
 
-double darctanh2(register double d){
-  register double c;
+double darctanh2(double d){
+  double c;
   c=1.0-d*d;
   return ldexp( d/(c*c) ,1);
 }

--- a/ascend/compiler/initialize.c
+++ b/ascend/compiler/initialize.c
@@ -132,7 +132,7 @@ static
 void InstanceNamePart(struct Name *n, struct Name **copy,
                       symchar **procname)
 {
-  register struct Name *ptr,*tmp;
+  struct Name *ptr,*tmp;
 
   /*FPRINTF(ASCERR,"INSTANCE NAME PART, input is n=");
   WriteName(ASCERR,n);
@@ -172,9 +172,9 @@ void InstanceNamePart(struct Name *n, struct Name **copy,
 struct InitProcedure *SearchProcList(CONST struct gl_list_t *l,
                                      symchar *name)
 {
-  register unsigned up,c,low;
-  register struct InitProcedure *ptr;
-  register int cmp;
+  unsigned up,c,low;
+  struct InitProcedure *ptr;
+  int cmp;
   assert(AscFindSymbol(name)!=NULL);
   if(l == NULL){
     return NULL;

--- a/ascend/compiler/instantiate.c
+++ b/ascend/compiler/instantiate.c
@@ -729,7 +729,7 @@ static
 int DeriveSetType(CONST struct Set *sptr, struct Instance *parent,
                   CONST unsigned int searchfor
 ){
-  register CONST struct Set *ptr;
+  CONST struct Set *ptr;
   int result=-1;		/* -1 indicates a failure */
   ptr = sptr;
   /* if it contains a range it must be an integer set */
@@ -4309,7 +4309,7 @@ int VerifyInsts(struct Instance *inst,
 static
 int SameClique(struct Instance *i1, struct Instance *i2)
 {
-  register struct Instance *i=i1;
+  struct Instance *i=i1;
   do {
     if (i==i2) return 1;
     i = NextCliqueMember(i);
@@ -12005,8 +12005,8 @@ static void ExecuteDefault(struct Instance *i
 	, struct Statement *stat,unsigned long int *depth
 ){
   struct gl_list_t *lvals;
-  register unsigned long c,length;
-  register struct Instance *ptr;
+  unsigned long c,length;
+  struct Instance *ptr;
   struct value_t value;
   REL_ERRORLIST err = REL_ERRORLIST_EMPTY;
   if(NULL != (lvals = FindInstances(i,DefaultStatVar(stat),&err))){
@@ -12129,8 +12129,8 @@ void ExecuteDefaultStatements(struct Instance *i,
                               struct gl_list_t *slist,
                               unsigned long int *depth)
 {
-  register unsigned long c,length;
-  register struct Statement *stat;
+  unsigned long c,length;
+  struct Statement *stat;
 
   if (slist){
     length = gl_length(slist);
@@ -12991,7 +12991,7 @@ int IncompleteArray(CONST struct Instance *i)
 {
   unsigned long c,len;
   struct Instance *child;
-  register struct TypeDescription *desc;
+  struct TypeDescription *desc;
   len = NumberChildren(i);
   for(c=1;c<=len;c++){
     child = InstanceChild(i,c);

--- a/ascend/compiler/instquery.c
+++ b/ascend/compiler/instquery.c
@@ -85,8 +85,8 @@ enum inst_t InstanceKindF(CONST struct Instance *i){
 
 
 unsigned long InstanceDepth(CONST struct Instance *i){
-  register unsigned long c,result=0,d;
-  register CONST struct Instance *parent;
+  unsigned long c,result=0,d;
+  CONST struct Instance *parent;
   if (i==NULL) return 0;
   AssertMemory(i);
   for(c=NumberParents(i);c>0;c--){
@@ -98,8 +98,8 @@ unsigned long InstanceDepth(CONST struct Instance *i){
 }
 
 unsigned long InstanceShortDepth(CONST struct Instance *i){
-  register unsigned long c,result=UINT_MAX,d;
-  register CONST struct Instance *parent;
+  unsigned long c,result=UINT_MAX,d;
+  CONST struct Instance *parent;
   if (i==NULL) return 0;
   AssertMemory(i);
   if (NumberParents(i)==0) return 1;
@@ -668,7 +668,7 @@ unsigned long InstanceIndirected(CONST struct Instance *i){
   return LONG_MAX;
 }
 
-symchar *InstanceType(register CONST struct Instance *i){
+symchar *InstanceType(CONST struct Instance *i){
   AssertMemory(i);
   switch(i->t) {
   case SIM_INST:	/* Not sure -- return the type of root */

--- a/ascend/compiler/interval.c
+++ b/ascend/compiler/interval.c
@@ -452,7 +452,7 @@ int IsIn(double d, struct Interval i)
 
 struct Interval PowInterval(struct Interval x, struct Interval y)
 {
-  register double a,b,c,d, t1, t2;
+  double a,b,c,d, t1, t2;
   struct Interval result;
   if (x.low < 0.0){
     ASC_PANIC("PowInterval call with a argument less than zero.\n");

--- a/ascend/compiler/library.c
+++ b/ascend/compiler/library.c
@@ -205,8 +205,8 @@ struct TypeDescription *FindType(symchar *name){
 }
 
 void DestroyLibrary(void){
-  register unsigned c;
-  register struct LibraryStructure *ptr,*next;
+  unsigned c;
+  struct LibraryStructure *ptr,*next;
   for(c=0;c<LIBRARYHASHSIZE;c++) {
     if(LibraryHashTable[c]!=NULL){
       ptr = LibraryHashTable[c];
@@ -232,8 +232,8 @@ void DestroyLibrary(void){
 
 
 struct gl_list_t *FindFundamentalTypes(void){
-  register unsigned c;
-  register struct LibraryStructure *ptr,*next;
+  unsigned c;
+  struct LibraryStructure *ptr,*next;
   struct TypeDescription *d;
   struct gl_list_t *fundies;
 
@@ -459,8 +459,8 @@ int AddType(struct TypeDescription *desc){
 
 struct  gl_list_t *DefinitionList(void){
   struct gl_list_t *result;
-  register unsigned c;
-  register struct LibraryStructure *ptr;
+  unsigned c;
+  struct LibraryStructure *ptr;
   result = gl_create(200L);
   for(c=0;c<LIBRARYHASHSIZE;c++){
     ptr = LibraryHashTable[c];
@@ -500,8 +500,8 @@ unsigned int CheckFundamental(symchar *f){
 
 struct gl_list_t *Asc_TypeByModule(CONST struct module_t *m){
   struct gl_list_t *result;
-  register unsigned c;
-  register struct LibraryStructure *ptr;
+  unsigned c;
+  struct LibraryStructure *ptr;
   CONST struct module_t *modptr;
 
   assert(m != NULL);
@@ -526,8 +526,8 @@ struct gl_list_t *Asc_TypeByModule(CONST struct module_t *m){
 
 struct gl_list_t *TypesThatRefineMe(symchar *name){
   struct gl_list_t *result;
-  register unsigned c;
-  register struct LibraryStructure *ptr;
+  unsigned c;
+  struct LibraryStructure *ptr;
   CONST struct TypeDescription *refdesc;
   symchar *refname;
 
@@ -560,8 +560,8 @@ struct gl_list_t *TypesThatRefineMe(symchar *name){
  */
 struct gl_list_t *AllTypesThatRefineMe_Flat(symchar *name){
   struct gl_list_t *result;
-  register unsigned c;
-  register struct LibraryStructure *ptr;
+  unsigned c;
+  struct LibraryStructure *ptr;
   struct TypeDescription *refdesc,*desc;
   //symchar *refname;
 
@@ -598,8 +598,8 @@ struct gl_list_t *AllTypesThatRefineMe_Flat(symchar *name){
 static
 struct gl_list_t *AllTypesThatRefineMe_FlatType(struct TypeDescription *desc){
   struct gl_list_t *result;
-  register unsigned c;
-  register struct LibraryStructure *ptr;
+  unsigned c;
+  struct LibraryStructure *ptr;
   struct TypeDescription *refdesc;
 
   if (!desc) { /* nobody home by that name */
@@ -673,7 +673,7 @@ static void EstablishPaternity(struct HierarchyNode *hd, struct gl_list_t *fl){
  */
 struct HierarchyNode *AllTypesThatRefineMe_Tree(symchar *name){
   struct gl_list_t *flatlist;
-  register unsigned c,end;
+  unsigned c,end;
   struct TypeDescription *refdesc,*desc;
   struct HierarchyNode *head;
 
@@ -726,8 +726,8 @@ void DestroyHierarchyNode(struct HierarchyNode *head){
 
 
 int IsTypeRefined(CONST struct TypeDescription *desc){
-  register unsigned c;
-  register struct LibraryStructure *ptr;
+  unsigned c;
+  struct LibraryStructure *ptr;
   CONST struct TypeDescription *refdesc;
 
   for(c=0;c<LIBRARYHASHSIZE;c++){

--- a/ascend/compiler/linkinst.c
+++ b/ascend/compiler/linkinst.c
@@ -191,7 +191,7 @@ void ChangeWhenPointers(struct Instance *when, struct Instance *old,
 void ChangeParent(struct Instance *parent, struct Instance *oldchild,
 		  struct Instance *newchild
 ){
-  register unsigned long c,length;
+  unsigned long c,length;
   AssertMemory(parent);
   length = NumberChildren(parent);
   for(c=1;c<=length;c++){
@@ -202,8 +202,8 @@ void ChangeParent(struct Instance *parent, struct Instance *oldchild,
 }
 
 void ReDirectParents(struct Instance *old, struct Instance *new){
-  register struct Instance *parent;
-  register unsigned long index1,length;
+  struct Instance *parent;
+  unsigned long index1,length;
   length = NumberParents(new);
   for(index1=1;index1<=length;index1++) {
     parent = InstanceParent(new,index1);
@@ -212,8 +212,8 @@ void ReDirectParents(struct Instance *old, struct Instance *new){
 }
 
 void ReDirectChildren(struct Instance *old, struct Instance *new){
-  register struct Instance *child;
-  register unsigned long c,length,pos;
+  struct Instance *child;
+  unsigned long c,length,pos;
   length = NumberChildren(new);
   for(c=1;c<=length;c++){
     if ((child = InstanceChild(new,c))!=NULL){
@@ -226,11 +226,11 @@ void ReDirectChildren(struct Instance *old, struct Instance *new){
 }
 
 
-void ReorderChildrenPtrs(register struct Instance **c,
-		register CONST ChildListPtr old, register CONST ChildListPtr new,
-		register unsigned long int olen, register unsigned long int nlen
+void ReorderChildrenPtrs(struct Instance **c,
+		CONST ChildListPtr old, CONST ChildListPtr new,
+		unsigned long int olen, unsigned long int nlen
 ){
-  register unsigned nzero;
+  unsigned nzero;
   if (olen==0) return;
   nzero = nlen-olen;
   while (nlen > 0) {
@@ -250,7 +250,7 @@ void ReorderChildrenPtrs(register struct Instance **c,
 	Remove old from the clique put new in its place.
 */
 void FixCliques(struct Instance *old, struct Instance *new){
-  register struct Instance *ptr,*next;
+  struct Instance *ptr,*next;
   ptr = new;
   /*  SetNextCliqueMember(ptr,NextCliqueMember(old)); not needed */
   while((next=NextCliqueMember(ptr))!=old)
@@ -266,7 +266,7 @@ void FixCliques(struct Instance *old, struct Instance *new){
  */
 void FixRelations(struct RealAtomInstance *old, struct RealAtomInstance *new)
 {
-  register unsigned long c,len;
+  unsigned long c,len;
   AssertMemory(old);
   AssertMemory(new);
   if ((new->relations==NULL)||(new->relations==old->relations)){
@@ -297,7 +297,7 @@ void FixRelations(struct RealAtomInstance *old, struct RealAtomInstance *new)
 
 static
 void FixLogRelationsIf(struct Instance *old, struct Instance *new){
-  register unsigned long c,len;
+  unsigned long c,len;
   if ((len=LogRelationsCount(new))>0){
     for(c=1;c<=len;c++) {
       ChangeLogRelPointers(LogRelationsForInstance(new,c),old,new);
@@ -307,7 +307,7 @@ void FixLogRelationsIf(struct Instance *old, struct Instance *new){
 
 static
 void FixLogRelationsElse(struct Instance *old, struct Instance *new){
-  register unsigned long c,len;
+  unsigned long c,len;
   if ((len=LogRelationsCount(INST(old)))>0){
     for(c=1;c<=len;c++){
       ChangeLogRelPointers(LogRelationsForInstance(old,c),old,new);
@@ -370,7 +370,7 @@ void FixLogRelations(struct Instance *old,
 
 static
 void FixWhensIf(struct Instance *old, struct Instance *new){
-  register unsigned long c,len;
+  unsigned long c,len;
   if ((len=WhensCount(new))>0){
     for(c=1;c<=len;c++) {
       ChangeWhenPointers(WhensForInstance(new,c),old,new);
@@ -380,7 +380,7 @@ void FixWhensIf(struct Instance *old, struct Instance *new){
 
 static
 void FixWhensElse(struct Instance *old, struct Instance *new){
-  register unsigned long c,len;
+  unsigned long c,len;
   if ((len=WhensCount(INST(old)))>0){
     for(c=1;c<=len;c++){
       ChangeWhenPointers(WhensForInstance(old,c),old,new);

--- a/ascend/compiler/logrelation.c
+++ b/ascend/compiler/logrelation.c
@@ -996,8 +996,8 @@ static void DestroyLogTermSide(struct logrel_side_temp *temp)
 
 void DestroyBVarList(struct gl_list_t *l, struct Instance *inst)
 {
-  register struct Instance *ptr;
-  register unsigned long c;
+  struct Instance *ptr;
+  unsigned long c;
   for(c=gl_length(l);c>=1;c--)
     if (NULL != (ptr = (struct Instance *)gl_fetch(l,c)))
       RemoveLogRel(ptr,inst);
@@ -1006,8 +1006,8 @@ void DestroyBVarList(struct gl_list_t *l, struct Instance *inst)
 
 void DestroySatRelList(struct gl_list_t *l, struct Instance *inst)
 {
-  register struct Instance *ptr;
-  register unsigned long c;
+  struct Instance *ptr;
+  unsigned long c;
   for(c=gl_length(l);c>=1;c--)
     if (NULL != (ptr = (struct Instance *)gl_fetch(l,c)))
       RemoveLogRel(ptr,inst);
@@ -1065,8 +1065,8 @@ void ChangeLogVarTermSide(union LogRelTermUnion *side,
 		          unsigned long int old,
 		          unsigned long int new)
 {
-  register long c;
-  register struct logrel_term *term;
+  long c;
+  struct logrel_term *term;
   for(c=len-1;c>=0;c--){
     term = LOGA_TERM(&(side[c]));
     switch (term->t){
@@ -1089,8 +1089,8 @@ void ChangeLogSatTermSide(union LogRelTermUnion *side,
 		          unsigned long int old,
 		          unsigned long int new)
 {
-  register long c;
-  register struct logrel_term *term;
+  long c;
+  struct logrel_term *term;
   for(c=len-1;c>=0;c--){
     term = LOGA_TERM(&(side[c]));
     switch (term->t){

--- a/ascend/compiler/mathinst.c
+++ b/ascend/compiler/mathinst.c
@@ -385,7 +385,7 @@ void AddRelation(struct Instance *i, struct Instance *reln){
 }
 
 void RemoveRelation(struct Instance *i, struct Instance *reln){
-	register unsigned long c;
+	unsigned long c;
 	//CONSOLE_DEBUG("Var %p: remove reference to rel %p",i,reln);
 	assert(i&&reln&&(reln->t==REL_INST));
 	AssertMemory(i);
@@ -510,7 +510,7 @@ void AddLogRel(struct Instance *i, struct Instance *lreln)
 
 void RemoveLogRel(struct Instance *i, struct Instance *lreln)
 {
-  register unsigned long c;
+  unsigned long c;
   assert(i&&lreln&&(lreln->t==LREL_INST));
   AssertMemory(i);
   switch(i->t) {
@@ -790,7 +790,7 @@ void AddWhen(struct Instance *i, struct Instance *when)
 
 void RemoveWhen(struct Instance *i, struct Instance *when)
 {
-  register unsigned long c;
+  unsigned long c;
   assert(i&&when&&(when->t==WHEN_INST));
   AssertMemory(i);
   switch(i->t) {

--- a/ascend/compiler/mergeinst.c
+++ b/ascend/compiler/mergeinst.c
@@ -133,7 +133,7 @@ int KeepWhichInstance(struct TypeDescription *d1,
     }
 #endif
   } else {
-    register struct TypeDescription *morerefined;
+  struct TypeDescription *morerefined;
     morerefined = MoreRefined(d1,d2);
     if (morerefined==d1) return 1;
     if (morerefined==d2) return 2;
@@ -151,7 +151,7 @@ be cannibalized. Merging value on constants here has a clique side effect.
 Returns 0 if happy, 1 or other if not.
 \*********************************************************************/
 {
-  register CONST dim_type *dim;
+  CONST dim_type *dim;
   assert(i1&&i2&&i1->t==i2->t);
   AssertMemory(i1);
   AssertMemory(i2);
@@ -237,14 +237,14 @@ Returns 0 if happy, 1 or other if not.
 	  /* heuristic to save the one with the lower address */
 #ifdef MEM_DECREASE
 	  if (SA_INST(i2)->list > SA_INST(i1)->list){
-	    register struct set_t *temp;
+	    struct set_t *temp;
 	    temp = SA_INST(i2)->list;
 	    SA_INST(i2)->list = SA_INST(i1)->list;
 	    SA_INST(i1)->list = temp;
 	  }
 #else
 	  if (SA_INST(i2)->list < SA_INST(i1)->list){
-	    register struct set_t *temp;
+	    struct set_t *temp;
 	    temp = SA_INST(i2)->list;
 	    SA_INST(i2)->list = SA_INST(i1)->list;
 	    SA_INST(i1)->list = temp;
@@ -327,14 +327,14 @@ Returns 0 if happy, 1 or other if not.
 	  /* heuristic to save the one with the lower address */
 #ifdef MEM_DECREASE
 	  if (S_INST(i2)->list > S_INST(i1)->list){
-	    register struct set_t *temp;
+	    struct set_t *temp;
 	    temp = S_INST(i2)->list;
 	    S_INST(i2)->list = S_INST(i1)->list;
 	    S_INST(i1)->list = temp;
 	  }
 #else
 	  if (S_INST(i2)->list < S_INST(i1)->list){
-	    register struct set_t *temp;
+	    struct set_t *temp;
 	    temp = S_INST(i2)->list;
 	    S_INST(i2)->list = S_INST(i1)->list;
 	    S_INST(i1)->list = temp;
@@ -446,8 +446,8 @@ void MergeParentLists(struct gl_list_t *l1,
 		      struct Instance *old,
 		      struct Instance *new)
 {
-  register unsigned long c,len;
-  register struct Instance *parent;
+  unsigned long c,len;
+  struct Instance *parent;
   len = gl_length(l2);
   for(c=1;c<=len;c++){
     parent = INST(gl_fetch(l2,c));
@@ -544,7 +544,7 @@ void MergeParents(struct Instance *i1, struct Instance *i2)
 static
 int mergeinst_InClique(struct Instance *i1, struct Instance *i2)
 {
-  register struct Instance *ptr;
+  struct Instance *ptr;
   ptr = i1;
   do{
     if (ptr==i2) return 1;
@@ -556,7 +556,7 @@ int mergeinst_InClique(struct Instance *i1, struct Instance *i2)
 /* wire together cliques, but does not mess with refinements */
 void MergeCliques(struct Instance *i1, struct Instance *i2)
 {
-  register struct Instance *tmp;
+  struct Instance *tmp;
   if (!mergeinst_InClique(i1,i2)){
     tmp = NextCliqueMember(i1);
     SetNextCliqueMember(i1,NextCliqueMember(i2));
@@ -690,7 +690,7 @@ void MergeModelValues(struct ModelInstance *i1, struct ModelInstance *i2)
 /*
  * assumes that i1 is more refined.  Checks the bitlists.
  */
-  register unsigned long c,len;
+  unsigned long c,len;
   len = BLength(i2->executed);
   for(c=0;c<len;c++)
     if (!ReadBit(i2->executed,c)) ClearBit(i1->executed,c);
@@ -961,8 +961,8 @@ int CheckArrayChildren(struct gl_list_t *l1,
 		       struct gl_list_t *l2,
 		       enum inst_t t)
 {
-  register unsigned long c,len;
-  register struct ArrayChild *child1,*child2;
+  unsigned long c,len;
+  struct ArrayChild *child1,*child2;
   if ((l1==NULL)||(l2==NULL)) return 0;
   len = gl_length(l1);
   if (gl_length(l2)!=len) return 1;

--- a/ascend/compiler/name.c
+++ b/ascend/compiler/name.c
@@ -157,7 +157,7 @@ void name_report_pool(void) {
 
 struct Name *CreateIdNameF(symchar *s,int bits)
 {
-  register struct Name *result;
+  struct Name *result;
   assert(s!=NULL);
   result = IDNMALLOC;
   assert(result!=NULL);
@@ -187,7 +187,7 @@ unsigned int NameLength(CONST struct Name *n)
 
 struct Name *CreateSetName(struct Set *s)
 {
-  register struct Name *result;
+  struct Name *result;
   assert(s!=NULL);
   result = IDNMALLOC;
   assert(result!=NULL);
@@ -274,8 +274,8 @@ CONST struct Set *NameSetPtrF(CONST struct Name *n)
 
 struct Name *CopyName(CONST struct Name *n)
 {
-  register struct Name *result,*p;
-  register CONST struct Name *np;
+  struct Name *result,*p;
+  CONST struct Name *np;
   if (n==NULL) return NULL;
   np = n;
   result = IDNMALLOC;
@@ -314,9 +314,9 @@ struct Name *CopyAppendNameNode(CONST struct Name *n, CONST struct Name *node)
   return result;
 }
 
-void DestroyName(register struct Name *n)
+void DestroyName(struct Name *n)
 {
-  register struct Name *next;
+  struct Name *next;
   while(n!=NULL) {
     next = n->next;
     if (!(n->bits & NAMEBIT_IDTY)) {
@@ -347,7 +347,7 @@ void DestroyNamePtr(struct Name *n)
 
 struct Name *JoinNames(struct Name *n1, struct Name *n2)
 {
-  register struct Name *p;
+  struct Name *p;
   if (n1==NULL) return n2;
   /* find end of name list */
   p = n1;
@@ -357,7 +357,7 @@ struct Name *JoinNames(struct Name *n1, struct Name *n2)
   return n1;
 }
 
-CONST struct Name *NextIdName(register CONST struct Name *n)
+CONST struct Name *NextIdName(CONST struct Name *n)
 {
   if (n==NULL) return NULL;
   assert(NameId(n)!=0);
@@ -368,9 +368,9 @@ CONST struct Name *NextIdName(register CONST struct Name *n)
   return n;
 }
 
-struct Name *ReverseName(register struct Name *n)
+struct Name *ReverseName(struct Name *n)
 {
-  register struct Name *next,*previous=NULL;
+  struct Name *next,*previous=NULL;
   if (n==NULL) return n;
   while (TRUE) {		/* loop until it returns */
     next = n->next;

--- a/ascend/compiler/packtest.c
+++ b/ascend/compiler/packtest.c
@@ -202,7 +202,7 @@ int CallBlackBox(struct Instance *inst,
 /**
 	When glassbox are registered, they must register a pointer
 	to their function jump table. In other words, they must
-	register a pointer to an 'array of pointers to functions'.
+  a pointer to an 'array of pointers to functions'.
 	This typedef just makes life a little cleaner.
 
 	<-- what typedef?? -- JP

--- a/ascend/compiler/parentchild.c
+++ b/ascend/compiler/parentchild.c
@@ -347,12 +347,12 @@ unsigned long SearchForParent(CONST struct Instance *i,
 struct InstanceName ParentsName(CONST struct Instance *p,
 				CONST struct Instance *c)
 {
-  register unsigned long count=1, num_children;
-  register struct Instance **child;
-  register ChildListPtr clist;
+  unsigned long count=1, num_children;
+  struct Instance **child;
+  ChildListPtr clist;
   struct InstanceName result;
-  register struct gl_list_t *arylist;
-  register struct ArrayChild *arychild;
+  struct gl_list_t *arylist;
+  struct ArrayChild *arychild;
   AssertMemory(p);
   AssertMemory(c);
   assert((p != NULL)&&(c != NULL));
@@ -613,8 +613,8 @@ unsigned long NumberChildren(CONST struct Instance *i)
 struct Instance *InstanceChild(CONST struct Instance *i,
 				   unsigned long int n)
 {
-  register struct ArrayChild *ptr;
-  register struct Instance **child;
+  struct ArrayChild *ptr;
+  struct Instance **child;
   assert((i!=NULL) && (n>0) && (n<=NumberChildren(i)));
   AssertMemory(i);
   switch(i->t) {
@@ -694,8 +694,8 @@ struct Instance *InstanceChild(CONST struct Instance *i,
 				   unsigned long int n)
 {
 #ifndef NDEBUG
-  register struct ArrayChild *ptr;
-  register struct Instance **child;
+  struct ArrayChild *ptr;
+  struct Instance **child;
   assert((i!=NULL) && (n>0) && (n<=NumberChildren(i)));
   AssertMemory(i);
   if (i->t & (IERRINST | ICHILDLESS)) {
@@ -812,7 +812,7 @@ struct Instance *InstanceChild(CONST struct Instance *i,
 
 struct InstanceName ChildName(CONST struct Instance *i, unsigned long int n)
 {
-  register struct ArrayChild *arychild;
+  struct ArrayChild *arychild;
   struct InstanceName result;
   assert((i!=NULL)&&(n>0)&&(n<=NumberChildren(i)));
   AssertMemory(i);
@@ -1009,11 +1009,11 @@ unsigned long ChildSearch(CONST struct Instance *i,
 unsigned long ChildIndex(CONST struct Instance *i,
 			 CONST struct Instance *child)
 {
-  register unsigned long count=1, num_children=0;
-  register struct Instance **childlist = NULL;
-  register ChildListPtr clist;
-  register struct gl_list_t *arylist;
-  register struct ArrayChild *arychild;
+  unsigned long count=1, num_children=0;
+  struct Instance **childlist = NULL;
+  ChildListPtr clist;
+  struct gl_list_t *arylist;
+  struct ArrayChild *arychild;
 
   assert((i!=NULL) && (child!=NULL));
   AssertMemory(i);
@@ -1100,8 +1100,8 @@ struct Instance *ChildByChar(CONST struct Instance *inst,symchar *name)
 void StoreChildPtr(struct Instance *i, unsigned long int n,
 		   struct Instance *child)
 {
-  register struct Instance **childptr;
-  register struct ArrayChild *ptr;
+  struct Instance **childptr;
+  struct ArrayChild *ptr;
   assert((i!=NULL)&&(n>0)&&(n<=NumberChildren(i)));
   AssertMemory(i);
   switch(i->t) {

--- a/ascend/compiler/pending.c
+++ b/ascend/compiler/pending.c
@@ -140,8 +140,8 @@ int NotDuplicated(struct pending_t *pl, struct Instance *inst)
 static
 unsigned long CalcNumberPending(void)
 {
-  register struct pending_t *ptr;
-  register unsigned long c=0;
+  struct pending_t *ptr;
+  unsigned long c=0;
   ptr = g_pending_list;
   while (ptr){
     AssertContainedMemory(ptr,sizeof(struct pending_t));
@@ -161,7 +161,7 @@ struct Instance *PendingInstanceF(CONST struct pending_t *pt)
 
 void ClearList(void)
 {
-  register struct pending_t *ptr,*next;
+  struct pending_t *ptr,*next;
 
   ptr = g_pending_list;
   g_pending_list_end = g_pending_list = NULL;
@@ -247,7 +247,7 @@ void AddBelow(struct pending_t *pt,
 
 void AddToEnd(struct Instance *i)
 {
-  register struct pending_t *ptr;
+  struct pending_t *ptr;
   assert(NotDuplicated(g_pending_list,i));
 #if FAST_PENDINGS
 #ifndef NDEBUG
@@ -289,7 +289,7 @@ void AddToEnd(struct Instance *i)
 #if FAST_PENDINGS
 void PendingInstanceRealloced(struct Instance *old, struct Instance *new)
 {
-  register struct pending_t *ptr;
+  struct pending_t *ptr;
   if (g_pending_list!=NULL){
     ptr = ((struct PendInstance *)(new))->p;
     /* handshake */
@@ -313,7 +313,7 @@ void PendingInstanceRealloced(struct Instance *old, struct Instance *new)
 #else
 void PendingInstanceRealloced(struct Instance *old, struct Instance *new)
 {
-  register struct pending_t *ptr;
+  struct pending_t *ptr;
   if (g_pending_list!=NULL){
     ptr = g_pending_list;
     while(ptr!=NULL){
@@ -332,7 +332,7 @@ void PendingInstanceRealloced(struct Instance *old, struct Instance *new)
 #if FAST_PENDINGS
 void RemoveInstance(struct Instance *i)
 {
-  register struct pending_t *ptr;
+  struct pending_t *ptr;
   if (g_pending_list!=NULL) {
 #ifndef NDEBUG
     if (InstanceKind(i) != MODEL_INST &&
@@ -358,7 +358,7 @@ void RemoveInstance(struct Instance *i)
 #else
 void RemoveInstance(struct Instance *i)
 {
-  register struct pending_t *ptr;
+  struct pending_t *ptr;
   ptr = g_pending_list;
   while(ptr){
     if (ptr->inst == i){
@@ -405,7 +405,7 @@ static void RemoveFromList(struct pending_t *pt)
 #if FAST_PENDINGS
 int InstanceInList(struct Instance *i)
 {
-  register struct pending_t *ptr;
+  struct pending_t *ptr;
 #ifndef NDEBUG
   if (InstanceKind(i) != MODEL_INST &&
       InstanceKind(i) != ARRAY_ENUM_INST &&
@@ -429,7 +429,7 @@ int InstanceInList(struct Instance *i)
 #else
 int InstanceInList(struct Instance *i)
 {
-  register struct pending_t *ptr;
+  struct pending_t *ptr;
   ptr = g_pending_list;
   while(ptr!=NULL){
     if (ptr->inst==i) return 1;

--- a/ascend/compiler/proc.c
+++ b/ascend/compiler/proc.c
@@ -55,7 +55,7 @@ static struct gl_list_t *g_model_definition_methods = NULL;
 struct InitProcedure *CreateProcedure(symchar *name,
 				      struct StatementList *stats)
 {
-  register struct InitProcedure *result;
+  struct InitProcedure *result;
   assert(AscFindSymbol(name)!=NULL);
   PMALLOC(result);
   assert(result!=NULL);
@@ -68,7 +68,7 @@ struct InitProcedure *CreateProcedure(symchar *name,
 
 struct InitProcedure *CopyProcedure(struct InitProcedure *p)
 {
-  register struct InitProcedure *result;
+  struct InitProcedure *result;
   assert(p!=NULL);
   PMALLOC(result);
   assert(result!=NULL);
@@ -80,7 +80,7 @@ struct InitProcedure *CopyProcedure(struct InitProcedure *p)
 
 struct InitProcedure *CopyProcToModify(struct InitProcedure *p)
 {
-  register struct InitProcedure *result;
+  struct InitProcedure *result;
   assert(p!=NULL);
   PMALLOC(result);
   assert(result!=NULL);
@@ -93,10 +93,10 @@ struct InitProcedure *CopyProcToModify(struct InitProcedure *p)
 struct gl_list_t *MergeProcedureLists(struct gl_list_t *old,
                                       struct gl_list_t *new)
 {
-  register struct gl_list_t *result;
-  register struct InitProcedure *proc;
-  register unsigned long c,len;
-  register unsigned long refproc;
+  struct gl_list_t *result;
+  struct InitProcedure *proc;
+  unsigned long c,len;
+  unsigned long refproc;
   if (old==NULL) {
     return new;
   }

--- a/ascend/compiler/prototype.c
+++ b/ascend/compiler/prototype.c
@@ -53,14 +53,14 @@ unsigned long g_proto_count=0;
 
 void InitializePrototype(void)
 {
-  register unsigned c;
+  unsigned c;
   for(c=0;c<PROTOTYPEHASHSIZE;g_proto_ht[c++]=NULL);
   g_proto_count = 0;
 }
 
 struct Instance *LookupPrototype(symchar *t)
 {
-  register struct ProtoRec *p;
+  struct ProtoRec *p;
   assert(AscFindSymbol(t)!=NULL);
 
   p = g_proto_ht[PROTOHASH(t)];
@@ -75,10 +75,10 @@ struct Instance *LookupPrototype(symchar *t)
 
 void AddPrototype(struct Instance *i)
 {
-  register unsigned long bucket;
-  register struct ProtoRec *p;
-  //register struct ProtoRec *prev;
-  register symchar *t;
+  unsigned long bucket;
+  struct ProtoRec *p;
+  //struct ProtoRec *prev;
+  symchar *t;
 
   t = InstanceType(i);
   p = g_proto_ht[bucket=PROTOHASH(t)];
@@ -121,8 +121,8 @@ void AddPrototype(struct Instance *i)
 
 void DeletePrototype(symchar *t)
 {
-  register struct ProtoRec *p,**prev;
-  register unsigned long bucket;
+  struct ProtoRec *p,**prev;
+  unsigned long bucket;
   assert(AscFindSymbol(t)!=NULL);
 
   p = g_proto_ht[bucket = PROTOHASH(t)];
@@ -147,8 +147,8 @@ void DeletePrototype(symchar *t)
 
 void DestroyPrototype(void)
 {
-  register unsigned c;
-  register struct ProtoRec *p,*next;
+  unsigned c;
+  struct ProtoRec *p,*next;
   for(c=0;c<PROTOTYPEHASHSIZE;c++){
     if ((p=g_proto_ht[c])!=NULL) {
       g_proto_ht[c]=NULL;

--- a/ascend/compiler/qlfdid.c
+++ b/ascend/compiler/qlfdid.c
@@ -216,7 +216,7 @@ int CheckChildExist(struct InstanceName name){
 
 
 struct gl_list_t *Asc_BrowQlfdidSearch(char *str, char *temp){
-  register char *ptr, *org;
+  char *ptr, *org;
   struct InstanceName name;
   struct gl_list_t *search_list = NULL;
   struct SearchEntry *se;
@@ -386,7 +386,7 @@ int Asc_QlfdidSearch2(char *str){
 */
 static
 struct Instance *BrowQlfdidSearch3(CONST char *str, char *temp,int relative){
-  register char *ptr;
+  char *ptr;
   struct InstanceName name;
   int ndx = 0;
   int open_bracket = 0;

--- a/ascend/compiler/refineinst.c
+++ b/ascend/compiler/refineinst.c
@@ -80,7 +80,7 @@
 /* checks children, and does some value copying in the process */
 static void CheckChild(struct Instance *old, struct Instance *new)
 {
-  register CONST dim_type *dimp;
+  CONST dim_type *dimp;
   assert(old->t==new->t);
   switch(old->t){
   case REAL_INST:
@@ -136,9 +136,9 @@ static void CheckChild(struct Instance *old, struct Instance *new)
 }
 
 static
-void CheckAtomValuesOne(register struct Instance **old,
-			register struct Instance **new,
-			register unsigned long int num)
+void CheckAtomValuesOne(struct Instance **old,
+			struct Instance **new,
+			unsigned long int num)
 {
   while(num--)
     CheckChild(*(old++),*(new++));
@@ -147,7 +147,7 @@ void CheckAtomValuesOne(register struct Instance **old,
 static
 void CheckAtomValuesTwo(struct Instance *old, struct Instance *new)
 {
-  register unsigned long c,num_children,pos;
+  unsigned long c,num_children,pos;
   struct InstanceName name;
   num_children = NumberChildren(old);
   for(c=1;c<=num_children;c++){
@@ -166,7 +166,7 @@ void CheckAtomValuesTwo(struct Instance *old, struct Instance *new)
 static struct Instance *RefineRealConstant(struct RealConstantInstance *i,
 					struct TypeDescription *type)
 {
-  register CONST dim_type *dimp;
+  CONST dim_type *dimp;
   unsigned what=0;
   /* bit game: bit 0 = update val,1 = update dim, bits 8,16= err in val/dim */
 
@@ -243,8 +243,8 @@ static struct Instance *RefineRealAtom(struct RealAtomInstance *i,
 			    struct TypeDescription *type)
 {
   struct RealAtomInstance *new;
-  register struct gl_list_t *tmp;
-  register CONST dim_type *dimp;
+  struct gl_list_t *tmp;
+  CONST dim_type *dimp;
   assert(MoreRefined(type,i->desc)==type);
   AssertMemory(i);
   if (i->desc==type) return INST(i);
@@ -354,8 +354,8 @@ RefineBooleanConstant(struct BooleanConstantInstance *i,
 static struct Instance *RefineBooleanAtom(struct BooleanAtomInstance *i,
 			       struct TypeDescription *type)
 {
-  register struct BooleanAtomInstance *new;
-  register struct gl_list_t *tmp;
+  struct BooleanAtomInstance *new;
+  struct gl_list_t *tmp;
   assert(MoreRefined(type,i->desc)==type);
   AssertMemory(i);
   if (i->desc==type) return INST(i);
@@ -433,8 +433,8 @@ static struct Instance
 static struct Instance *RefineIntegerAtom(struct IntegerAtomInstance *i,
 			       struct TypeDescription *type)
 {
-  register struct gl_list_t *tmp;
-  register struct IntegerAtomInstance *new;
+  struct gl_list_t *tmp;
+  struct IntegerAtomInstance *new;
   assert(MoreRefined(type,i->desc)==type);
   AssertMemory(i);
   if (i->desc==type) return INST(i);
@@ -478,8 +478,8 @@ static struct Instance *RefineIntegerAtom(struct IntegerAtomInstance *i,
 static struct Instance *RefineSet(struct SetAtomInstance *i,
 			   struct TypeDescription *type)
 {
-  register struct gl_list_t *tmp;
-  register struct SetAtomInstance *new;
+  struct gl_list_t *tmp;
+  struct SetAtomInstance *new;
   assert(MoreRefined(type,i->desc)==type);
   AssertMemory(i);
   if (i->desc==type) return INST(i);
@@ -548,8 +548,8 @@ static struct Instance *RefineSymbolConstant(struct SymbolConstantInstance *i,
 static struct Instance *RefineSymbolAtom(struct SymbolAtomInstance *i,
 			      struct TypeDescription *type)
 {
-  register struct gl_list_t *tmp;
-  register struct SymbolAtomInstance *new;
+  struct gl_list_t *tmp;
+  struct SymbolAtomInstance *new;
   assert(MoreRefined(type,i->desc)==type);
   AssertMemory(i);
   if (i->desc==type) return INST(i);
@@ -604,8 +604,8 @@ struct Instance *RefineModel(struct ModelInstance *i,
                              struct ModelInstance *arginst)
 {
   struct TypeDescription *oldtype;
-  register unsigned long new_length,old_length;
-  register struct ModelInstance *result;
+  unsigned long new_length,old_length;
+  struct ModelInstance *result;
   assert(MoreRefined(type,i->desc)==type);
   AssertMemory(i);
   AssertMemory(type);

--- a/ascend/compiler/rel_common.c
+++ b/ascend/compiler/rel_common.c
@@ -51,7 +51,7 @@ void Swap(unsigned long int *p1, unsigned long int *p2)
 }
 
 
-CONST struct Expr *FindLastExpr(register CONST struct Expr *ex)
+CONST struct Expr *FindLastExpr(CONST struct Expr *ex)
 {
   assert(ex!=NULL);
   while(NextExpr(ex)!=NULL) ex = NextExpr(ex);

--- a/ascend/compiler/relation.c
+++ b/ascend/compiler/relation.c
@@ -90,10 +90,10 @@ static union RelationTermUnion
 
 #ifdef THIS_IS_AN_UNUSED_FUNCTION
 static
-unsigned long ExprLength(register CONST struct Expr *start,
-			 register CONST struct Expr *stop)
+unsigned long ExprLength(CONST struct Expr *start,
+			 CONST struct Expr *stop)
 {
-  register unsigned long result=0;
+  unsigned long result=0;
   while(start!=stop){
     start = NextExpr(start);
     result++;
@@ -861,11 +861,11 @@ static int check_gt1(unsigned long i) {
  *             ^----next = next free location to put an index in termstack
  */
 static unsigned long SimplifyTermBuf(int level,
-				 register struct relation_term ** CONST b,
+				 struct relation_term ** CONST b,
 				 CONST unsigned long blen)
 {
-  register unsigned long next;
-  register unsigned long *ts; /* term stack, should we need it */
+  unsigned long next;
+  unsigned long *ts; /* term stack, should we need it */
   unsigned long top;
   long last;
   unsigned long right;
@@ -2318,7 +2318,7 @@ static int ProcessListRange(CONST struct Instance *ref
 }
 
 static
-CONST struct Expr *ExprContainsSuchThat(register CONST struct Expr *ex){
+CONST struct Expr *ExprContainsSuchThat(CONST struct Expr *ex){
   while(ex!=NULL){
     if (ExprType(ex)==e_st) return ex;
     ex = NextExpr(ex);
@@ -3373,8 +3373,8 @@ static void DestroyTermSide(struct relation_side_temp *temp)
 	@param inst	relation instance to be removed from the relations list belonging to each variable
 */
 void DestroyVarList(struct gl_list_t *l, struct Instance *relinst){
-  register struct Instance *ptr;
-  register unsigned long c;
+  struct Instance *ptr;
+  unsigned long c;
   for(c=gl_length(l);c>=1;c--){
     if(NULL != (ptr = (struct Instance *)gl_fetch(l,c))){
       //CONSOLE_DEBUG("Destroy var list");
@@ -3486,8 +3486,8 @@ void ChangeTermSide(union RelationTermUnion *side,
 		    unsigned long int old,
 		    unsigned long int new)
 {
-  register long c;
-  register struct relation_term *term;
+  long c;
+  struct relation_term *term;
   for(c=len-1;c>=0;c--){
     term = A_TERM(&(side[c]));
     if (term->t == e_var){

--- a/ascend/compiler/safe.c
+++ b/ascend/compiler/safe.c
@@ -235,7 +235,7 @@ double safe_rec(double x,enum safe_err *safe){
 #define CUBRTHUGE      5.6438030941223618e102
 /* largest cubeable number in an 8 byte ieee double */
 #endif
-double safe_cube(register double x,enum safe_err *safe)
+double safe_cube(double x,enum safe_err *safe)
 {
    if( fabs(x) > CUBRTHUGE || fabs(x) < INV_CUBRTHUGE ) {
       double bogus;
@@ -298,7 +298,7 @@ double safe_erf_inv(double x,enum safe_err *safe)
 
 double safe_lnm_inv(double x,enum safe_err *safe)
 {
-   register double eps=FuncGetLnmEpsilon();
+  double eps=FuncGetLnmEpsilon();
 
    if( x > (DBL_MAX > 1.0e308 ? 709.196209 : log(DBL_MAX)) ) {
       double bogus = BIGNUM;
@@ -711,7 +711,7 @@ double safe_tanh_D2(double x,enum safe_err *safe)
 
 double safe_arcsin_D2(double x,enum safe_err *safe)
 {
-   register double t;
+  double t;
    t = safe_rec(1.0 - safe_sqr_D0(x,safe),safe);
    return( safe_mul_D0( safe_mul_D0(x,t,safe) , safe_mul_D0(t,t,safe) ,safe) );
 }

--- a/ascend/compiler/select.c
+++ b/ascend/compiler/select.c
@@ -42,7 +42,7 @@
 
 struct SelectList *CreateSelect(struct Set *set, struct StatementList *sl)
 {
-  register struct SelectList *result;
+  struct SelectList *result;
   SELMALLOC(result);
   result->slist = sl;
   result->values =set;
@@ -52,7 +52,7 @@ struct SelectList *CreateSelect(struct Set *set, struct StatementList *sl)
 
 struct SelectList *ReverseSelectCases(struct SelectList *sel)
 {
-  register struct SelectList *next,*previous=NULL;
+  struct SelectList *next,*previous=NULL;
   if (sel==NULL) return sel;
   while (1) {			/* loop until broken */
     next = sel->next;
@@ -66,7 +66,7 @@ struct SelectList *ReverseSelectCases(struct SelectList *sel)
 struct SelectList *LinkSelectCases(struct SelectList *sel1,
 				   struct SelectList *sel2)
 {
-  register struct SelectList *p;
+  struct SelectList *p;
   p = sel1;
   while (p->next!=NULL) p = p->next;
   p->next = sel2;
@@ -95,7 +95,7 @@ struct StatementList *SelectStatementListF(struct SelectList *sel)
 
 void DestroySelectNode(struct SelectList *sel)
 {
-  register struct Set *set;
+  struct Set *set;
   if (sel!=NULL){
     set = sel->values;
     if (sel->values) {
@@ -114,7 +114,7 @@ void DestroySelectNode(struct SelectList *sel)
 
 void DestroySelectList(struct SelectList *sel)
 {
-  register struct SelectList *next;
+  struct SelectList *next;
   while (sel!=NULL){
     next = NextSelectCase(sel);
     DestroySelectNode(sel);
@@ -124,7 +124,7 @@ void DestroySelectList(struct SelectList *sel)
 
 struct SelectList *CopySelectNode(struct SelectList *sel)
 {
-  register struct SelectList *result;
+  struct SelectList *result;
   assert(sel);
   SELMALLOC(result);
   if (sel->values) result->values = CopySetByReference(sel->values);
@@ -136,7 +136,7 @@ struct SelectList *CopySelectNode(struct SelectList *sel)
 
 struct SelectList *CopySelectList(struct SelectList *sel)
 {
-  register struct SelectList *head=NULL,*p;
+  struct SelectList *head=NULL,*p;
   if (sel!=NULL) {
     p = head = CopySelectNode(sel);
     sel = sel->next;

--- a/ascend/compiler/setinstval.c
+++ b/ascend/compiler/setinstval.c
@@ -123,7 +123,7 @@ int SetStrCmp(CONST char *s1, CONST char *s2)
 
 struct set_t *CreateEmptySet(void)
 {
-  register struct set_t *result;
+  struct set_t *result;
   assert(sizeof(asc_intptr_t)==sizeof(char *));
   MALLOCSET(result);
   result->kind = empty_set;
@@ -182,7 +182,7 @@ void InsertString(struct set_t *set, symchar *str){
 
 void InsertIntegerRange(struct set_t *set, long int lower, long int upper)
 {
-  register long i;
+  long i;
   assert(set&&((set->kind==integer_set)||(set->kind==empty_set)));
   for(i=lower;i<=upper;InsertInteger(set,i++));
 }
@@ -190,8 +190,8 @@ void InsertIntegerRange(struct set_t *set, long int lower, long int upper)
 struct set_t *SetUnion(CONST struct set_t *s1, CONST struct set_t *s2)
 {
   struct set_t *result;
-  register unsigned long c1,l1,c2,l2;
-  register int cmp;
+  unsigned long c1,l1,c2,l2;
+  int cmp;
   CmpFunc func;
   assert(s1&&s2);
   if (s1->kind==empty_set) return CopySet(s2);
@@ -242,8 +242,8 @@ struct set_t *SetUnion(CONST struct set_t *s1, CONST struct set_t *s2)
 struct set_t *SetIntersection(CONST struct set_t *s1, CONST struct set_t *s2)
 {
   struct set_t *result;
-  register unsigned long c1,l1,c2,l2;
-  register int cmp;
+  unsigned long c1,l1,c2,l2;
+  int cmp;
   CmpFunc func;
   assert(s1&&s2);
   if (s1->kind==empty_set) return CreateEmptySet();
@@ -284,8 +284,8 @@ struct set_t *SetIntersection(CONST struct set_t *s1, CONST struct set_t *s2)
 struct set_t *SetDifference(CONST struct set_t *s1, CONST struct set_t *s2)
 {
   struct set_t *result;
-  register unsigned long c1,l1,c2,l2;
-  register int cmp;
+  unsigned long c1,l1,c2,l2;
+  int cmp;
   CmpFunc func;
   assert(s1&&s2);
   if (s1->kind==empty_set) return CreateEmptySet();
@@ -322,7 +322,7 @@ struct set_t *SetDifference(CONST struct set_t *s1, CONST struct set_t *s2)
 
 struct set_t *CopySet(CONST struct set_t *set)
 {
-  register struct set_t *result;
+  struct set_t *result;
   assert(set!=NULL);
   MALLOCSET(result);
   result->kind = set->kind;
@@ -396,7 +396,7 @@ enum set_kind SetKind(CONST struct set_t *s)
 
 int SetsEqual(CONST struct set_t *s1, CONST struct set_t *s2)
 {
-  register unsigned long c,length;
+  unsigned long c,length;
   assert(s1&&s2);
   if (s1->kind!=s2->kind) return 0;
   if (s1->list==NULL) {
@@ -424,7 +424,7 @@ int SetsEqual(CONST struct set_t *s1, CONST struct set_t *s2)
 
 int Subset(CONST struct set_t *s1, CONST struct set_t *s2)
 {
-  register asc_intptr_t c1,c2,length1,length2;
+  asc_intptr_t c1,c2,length1,length2;
   assert(s1&&s2);
   if (s1->kind==empty_set) return 1;
   if (s2->kind==empty_set) return 0;
@@ -436,7 +436,7 @@ int Subset(CONST struct set_t *s1, CONST struct set_t *s2)
   if (length1>length2) return 0;
   c1=c2=1;
   if (s1->kind == integer_set) {
-    register long i1,i2;
+  long i1,i2;
     while((c1<=length1)&&(c2<=length2)) {
       i1 = (asc_intptr_t)gl_fetch(s1->list,c1);
       i2 = (asc_intptr_t)gl_fetch(s2->list,c2);
@@ -448,8 +448,8 @@ int Subset(CONST struct set_t *s1, CONST struct set_t *s2)
     }
   }
   else {
-    register char *str1,*str2;
-    register int cmp;
+  char *str1,*str2;
+  int cmp;
     while((c1<=length1)&&(c2<=length2)) {
       str1 = gl_fetch(s1->list,c1);
       str2 = gl_fetch(s2->list,c2);

--- a/ascend/compiler/sets.c
+++ b/ascend/compiler/sets.c
@@ -180,7 +180,7 @@ CONST struct Expr *GetUpperExprF(CONST struct Set *s)
 
 struct Set *CopySetNode(CONST struct Set *s)
 {
-  register struct Set *result;
+  struct Set *result;
   if (s==NULL) {
     return NULL;
   }
@@ -199,7 +199,7 @@ struct Set *CopySetNode(CONST struct Set *s)
 
 struct Set *CopySetList(CONST struct Set *s)
 {
-  register struct Set *result,*p;
+  struct Set *result,*p;
   if (s==NULL) {
     return NULL;
   }
@@ -242,7 +242,7 @@ void DestroySetNode(struct Set *s)
 
 void DestroySetList(struct Set *s)
 {
-  register struct Set *next;
+  struct Set *next;
   while (s!=NULL) {
 #if SETUSESPOOL
     AssertMemory(s);
@@ -268,7 +268,7 @@ void DestroySetHead(struct Set *s)
 
 void DestroySetListByReference(struct Set *s)
 {
-  register struct Set *next;
+  struct Set *next;
   if (--s->ref_count == 0){
     while (s!=NULL) {
 #if SETUSESPOOL
@@ -308,7 +308,7 @@ void DestroySetNodeByReference(struct Set *s)
 
 struct Set *JoinSetLists(struct Set *s1, struct Set *s2)
 {
-  register struct Set *s;
+  struct Set *s;
   if (s1==NULL) return s2;
   s = s1;
   /* find end of set list */
@@ -318,9 +318,9 @@ struct Set *JoinSetLists(struct Set *s1, struct Set *s2)
   return s1;
 }
 
-struct Set *ReverseSetList(register struct Set *s)
+struct Set *ReverseSetList(struct Set *s)
 {
-  register struct Set *next,*previous=NULL;
+  struct Set *next,*previous=NULL;
   if (s==NULL) return s;
   while (TRUE) {		/* loop until broken */
     next = s->next;
@@ -400,7 +400,7 @@ int CompareSetStructures(CONST struct Set *s1, CONST struct Set *s2)
 
 unsigned long SetLength(CONST struct Set *set)
 {
-  register unsigned long l=0;
+  unsigned long l=0;
   while (set!=NULL){
     l++;
     set = NextSet(set);

--- a/ascend/compiler/slist.c
+++ b/ascend/compiler/slist.c
@@ -99,9 +99,9 @@ struct StatementList *CopyStatementList(struct StatementList *sl)
 
 struct StatementList *CopyListToModify(struct StatementList *sl)
 {
-  register struct StatementList *result;
-  register struct Statement *s;
-  register unsigned long c,len;
+  struct StatementList *result;
+  struct Statement *s;
+  unsigned long c,len;
   assert(sl!=NULL);
   assert(sl->ref_count);
   result=SLMALLOC;
@@ -217,7 +217,7 @@ int CompareISLists(CONST struct StatementList *sl1,
 
 void AppendStatement(struct StatementList *sl1, struct Statement *s)
 {
-  register struct gl_list_t *l1;
+  struct gl_list_t *l1;
 
   assert(s!=NULL);
   if (sl1 ==NULL) {
@@ -231,10 +231,10 @@ void AppendStatement(struct StatementList *sl1, struct Statement *s)
 struct StatementList *AppendStatementLists(CONST struct StatementList *sl1,
                                            struct StatementList *sl2)
 {
-  register CONST struct gl_list_t *l1;
-  register struct gl_list_t *list,*l2;
-  register struct Statement *stat;
-  register unsigned long c,len;
+  CONST struct gl_list_t *l1;
+  struct gl_list_t *list,*l2;
+  struct Statement *stat;
+  unsigned long c,len;
   assert(sl1 && sl2);
   l1 = GetList(sl1);
   l2 = GetList(sl2);
@@ -260,7 +260,7 @@ struct StatementList *AppendStatementLists(CONST struct StatementList *sl1,
 
 void DestroyStatementList(struct StatementList *sl)
 {
-  register unsigned long c,len;
+  unsigned long c,len;
   if (sl == NULL) return;
   assert(sl->ref_count!=0);
   if (sl->ref_count < MAXREFCOUNT) sl->ref_count--;

--- a/ascend/compiler/statement.c
+++ b/ascend/compiler/statement.c
@@ -263,7 +263,7 @@ struct Statement *CreateWILLBE(struct VariableList *vl, symchar *t,
 struct Statement *CreateIRT(struct VariableList *vl, symchar *t,
                             struct Set *ta)
 {
-  register struct Statement *result;
+  struct Statement *result;
   result=create_statement_here(IRT);
   result->v.i.type = t;
   result->v.i.typeargs = ta;
@@ -275,7 +275,7 @@ struct Statement *CreateIRT(struct VariableList *vl, symchar *t,
 
 struct Statement *CreateAA(struct VariableList *vl)
 {
-  register struct Statement *result;
+  struct Statement *result;
   result=create_statement_here(AA);
   result->v.a.vl = vl;
   return result;
@@ -284,7 +284,7 @@ struct Statement *CreateAA(struct VariableList *vl)
 
 struct Statement *IgnoreLNK(symchar *key, struct Name *n_key, struct VariableList *vl)
 {
-  register struct Statement *result;
+  struct Statement *result;
   result=create_statement_here(LNK);
 
   if(key != NULL){
@@ -301,7 +301,7 @@ struct Statement *IgnoreLNK(symchar *key, struct Name *n_key, struct VariableLis
 
 struct Statement *CreateLNK(symchar *key, struct Name *n_key, struct VariableList *vl)
 {
-  register struct Statement *result;
+  struct Statement *result;
   result=create_statement_here(LNK);
 
   if(key != NULL){
@@ -319,7 +319,7 @@ struct Statement *CreateLNK(symchar *key, struct Name *n_key, struct VariableLis
 
 struct Statement *CreateUNLNK(symchar *key, struct Name *n_key, struct VariableList *vl)
 {
-  register struct Statement *result;
+  struct Statement *result;
   result=create_statement_here(UNLNK);
 
   if(key != NULL){
@@ -337,14 +337,14 @@ return result;
 
 struct Statement *CreateATS(struct VariableList *vl)
 {
-  register struct Statement *result;
+  struct Statement *result;
   result=create_statement_here(ATS);
   result->v.a.vl = vl;
   return result;
 }
 
 struct Statement *CreateFIX(struct VariableList *vars){
-	register struct Statement *result;
+	struct Statement *result;
 	/*CONSOLE_DEBUG("CREATING FIX STMT");*/
 	result=create_statement_here(FIX);
 	result->v.fx.vars = vars;
@@ -353,7 +353,7 @@ struct Statement *CreateFIX(struct VariableList *vars){
 }
 
 struct Statement *CreateFREE(struct VariableList *vars){
-  register struct Statement *result;
+  struct Statement *result;
   /* CONSOLE_DEBUG("CREATING FREE STMT"); */
   result=create_statement_here(FREE);
   result->v.fx.vars = vars;
@@ -361,7 +361,7 @@ struct Statement *CreateFREE(struct VariableList *vars){
 }
 
 struct Statement *CreateSOLVER(CONST char *solvername){
-	register struct Statement *result;
+	struct Statement *result;
 	result=create_statement_here(SOLVER);
 	result->v.solver.name = solvername;
 	/*CONSOLE_DEBUG("CREATED SOLVER STATEMENT");*/
@@ -369,7 +369,7 @@ struct Statement *CreateSOLVER(CONST char *solvername){
 }
 
 struct Statement *CreateOPTION(CONST char *optname, struct Expr *rhs){
-	register struct Statement *result;
+	struct Statement *result;
 	result=create_statement_here(OPTION);
 	result->v.option.name = optname;
 	result->v.option.rhs = rhs;
@@ -377,14 +377,14 @@ struct Statement *CreateOPTION(CONST char *optname, struct Expr *rhs){
 }
 
 struct Statement *CreateSOLVE(){
-	register struct Statement *result;
+	struct Statement *result;
 	result=create_statement_here(SOLVE);
 	return result;
 }
 
 struct Statement *CreateWBTS(struct VariableList *vl)
 {
-  register struct Statement *result;
+  struct Statement *result;
   result=create_statement_here(WBTS);
   result->v.a.vl = vl;
   return result;
@@ -392,7 +392,7 @@ struct Statement *CreateWBTS(struct VariableList *vl)
 
 struct Statement *CreateWNBTS(struct VariableList *vl)
 {
-  register struct Statement *result;
+  struct Statement *result;
   result=create_statement_here(WNBTS);
   result->v.a.vl = vl;
   return result;
@@ -491,7 +491,7 @@ struct Statement *CreateFOR(symchar *sindex,
 			    struct StatementList *stmts,
 			    enum ForOrder order, enum ForKind kind)
 {
-  register struct Statement *result;
+  struct Statement *result;
   result=create_statement_here(FOR);
   result->v.f.index = sindex;
   result->v.f.e = expr;
@@ -505,7 +505,7 @@ struct Statement *CreateFOR(symchar *sindex,
 
 struct Statement *CreateFlow(enum FlowControl fc, CONST char *mt)
 {
-  register struct Statement *result;
+  struct Statement *result;
 
   switch (fc) {
   case fc_break:
@@ -538,7 +538,7 @@ void SetRelationName(struct Statement *stat, struct Name *n)
 
 struct Statement *CreateREL(struct Name *n, struct Expr *relation)
 {
-  register struct Statement *result;
+  struct Statement *result;
   result=create_statement_here(REL);
   result->v.rel.nptr = n;
   result->v.rel.relation = relation;
@@ -555,7 +555,7 @@ void SetLogicalRelName(struct Statement *stat, struct Name *n)
 
 struct Statement *CreateLOGREL(struct Name *n, struct Expr *logrel)
 {
-  register struct Statement *result;
+  struct Statement *result;
   result=create_statement_here(LOGREL);
   result->v.lrel.nptr = n;
   result->v.lrel.logrel = logrel;
@@ -569,7 +569,7 @@ struct Statement *CreateEXTERNGlassBox(
 			       struct Name *data,
 			       struct Name *scope)
 {
-  register struct Statement *result;
+  struct Statement *result;
   ERROR_REPORTER_NOTE("Found glassbox equation statement '%s'\n",funcname);
 
   result=create_statement_here(EXT);
@@ -590,7 +590,7 @@ struct Statement *CreateEXTERNBlackBox(
 			       unsigned long n_inputs,
 			       unsigned long n_outputs)
 {
-  register struct Statement *result;
+  struct Statement *result;
   struct Name *bbsuffix;
   symchar *bsuf;
   /* ERROR_REPORTER_DEBUG("Found blackbox equation statement '%s'\n",funcname); */
@@ -620,7 +620,7 @@ struct Statement *CreateEXTERNMethod(
 			       CONST char *funcname,
 			       struct VariableList *vl)
 {
-  register struct Statement *result;
+  struct Statement *result;
   /* ERROR_REPORTER_DEBUG("Found external method statement '%s'\n",funcname); */
   result=create_statement_here(EXT);
   result->v.ext.mode = ek_method;
@@ -634,7 +634,7 @@ struct Statement *CreateREF(struct VariableList *vl,
 			    symchar *st,
 			    int mode)
 {
-  register struct Statement *result;
+  struct Statement *result;
   result=create_statement_here(REF);
   result->v.ref.mode = mode;
   result->v.ref.ref_name = ref_name;
@@ -645,7 +645,7 @@ struct Statement *CreateREF(struct VariableList *vl,
 
 struct Statement *CreateRUN(struct Name *n,struct Name *type_access)
 {
-  register struct Statement *result;
+  struct Statement *result;
   result=create_statement_here(RUN);
   result->v.r.proc_name = n;
   result->v.r.type_name = type_access; /* NULL is valid */
@@ -654,7 +654,7 @@ struct Statement *CreateRUN(struct Name *n,struct Name *type_access)
 
 struct Statement *CreateCALL(symchar *sym,struct Set *args)
 {
-  register struct Statement *result;
+  struct Statement *result;
   result=create_statement_here(CALL);
   result->v.call.id = sym;
   result->v.call.args = args; /* NULL is valid */
@@ -662,7 +662,7 @@ struct Statement *CreateCALL(symchar *sym,struct Set *args)
 }
 
 struct Statement *CreateASSERT(struct Expr *ex){
-  register struct Statement *result;
+  struct Statement *result;
   result=create_statement_here(ASSERT);
   result->v.asserts.test = ex;
   return result;
@@ -672,7 +672,7 @@ struct Statement *CreateIF(struct Expr *ex,
 			   struct StatementList *thenblock,
 			   struct StatementList *elseblock)
 {
-  register struct Statement *result;
+  struct Statement *result;
   result=create_statement_here(IF);
   result->v.ifs.test = ex;
   result->v.ifs.thenblock = thenblock;
@@ -689,7 +689,7 @@ struct Statement *CreateIF(struct Expr *ex,
 struct Statement *CreateWhile(struct Expr *ex,
 			   struct StatementList *thenblock)
 {
-  register struct Statement *result;
+  struct Statement *result;
   result=create_statement_here(WHILE);
   result->v.loop.test = ex;
   result->v.loop.block = thenblock;
@@ -703,7 +703,7 @@ struct Statement *CreateWHEN(struct Name *wname, struct VariableList *vlist,
                              struct WhenList *wl)
 {
   struct StatementList *sl;
-  register struct Statement *result;
+  struct Statement *result;
   result=create_statement_here(WHEN);
   result->v.w.nptr = wname;
   result->v.w.vl = vlist;
@@ -718,7 +718,7 @@ struct Statement *CreateWHEN(struct Name *wname, struct VariableList *vlist,
 
 struct Statement *CreateFNAME(struct Name *name)
 {
-  register struct Statement *result;
+  struct Statement *result;
   result=create_statement_here(FNAME);
   result->v.n.wname = name;
   return result;
@@ -728,7 +728,7 @@ struct Statement *CreateFNAME(struct Name *name)
 struct Statement *CreateSWITCH(struct VariableList *v, struct SwitchList *sw)
 {
   struct StatementList *sl;
-  register struct Statement *result;
+  struct Statement *result;
   result=create_statement_here(SWITCH);
   result->v.sw.vl = v;
   result->v.sw.cases = sw;
@@ -781,7 +781,7 @@ struct Statement *CreateSELECT(struct VariableList *v, struct SelectList *sel)
 {
   unsigned int tmp=0;
   struct StatementList *sl;
-  register struct Statement *result;
+  struct Statement *result;
   result=create_statement_here(SELECT);
   result->v.se.vl = v;
   result->v.se.cases = sel;
@@ -799,7 +799,7 @@ struct Statement *CreateSELECT(struct VariableList *v, struct SelectList *sel)
 
 struct Statement *CreateCOND(struct StatementList *stmts)
 {
-  register struct Statement *result;
+  struct Statement *result;
   result=create_statement_here(COND);
   result->v.cond.stmts = stmts;
   AddContext(stmts,context_COND);
@@ -810,7 +810,7 @@ struct Statement *CreateCOND(struct StatementList *stmts)
 
 struct Statement *CreateASSIGN(struct Name *n, struct Expr *rhs)
 {
-  register struct Statement *result;
+  struct Statement *result;
   result=create_statement_here(ASGN);
   result->v.asgn.nptr = n;
   result->v.asgn.rhs = rhs;
@@ -819,7 +819,7 @@ struct Statement *CreateASSIGN(struct Name *n, struct Expr *rhs)
 
 struct Statement *CreateCASSIGN(struct Name *n, struct Expr *rhs)
 {
-  register struct Statement *result;
+  struct Statement *result;
   result=create_statement_here(CASGN);
   result->v.asgn.nptr = n;
   result->v.asgn.rhs = rhs;
@@ -1065,7 +1065,7 @@ void DestroyStatement(struct Statement *s)
 
 struct Statement *CopyToModify(struct Statement *s)
 {
-  register struct Statement *result;
+  struct Statement *result;
   size_t size;
   assert(s!=NULL);
   assert(s->ref_count);

--- a/ascend/compiler/statio.c
+++ b/ascend/compiler/statio.c
@@ -104,8 +104,8 @@ void statio_clear_stattypenames(void){
 
 
 static
-void Indent(FILE *f, register int i){
-  register int tabs;
+void Indent(FILE *f, int i){
+  int tabs;
   if (i<=0) return;
   tabs = i / 8;
   while (tabs--) PUTC('\t',f);
@@ -141,7 +141,7 @@ void WriteOrder(FILE *f, enum ForOrder o){
 
 static
 void WriteWhenNode(FILE *f,struct WhenList *w, int i){
-  register struct Set *set;
+  struct Set *set;
   Indent(f,i);
   set = WhenSetList(w);
   if (set!=NULL){
@@ -163,7 +163,7 @@ void WriteWhenList(FILE *f, struct WhenList *w, int i){
 
 static 
 void WriteSelectNode(FILE *f, struct SelectList *sel, int i){
-  register struct Set *set;
+  struct Set *set;
   Indent(f,i);
   set = SelectSetList(sel);
   if (set!=NULL){
@@ -187,7 +187,7 @@ void WriteSelectList(FILE *f, struct SelectList *sel, int i)
 
 static
 void WriteSwitchNode(FILE *f, struct SwitchList *sw, int i){
-  register struct Set *set;
+  struct Set *set;
   Indent(f,i);
   set = SwitchSetList(sw);
   if (set!=NULL){
@@ -209,8 +209,8 @@ void WriteSwitchList(FILE *f, struct SwitchList *sw, int i){
 }
 
 struct gl_list_t *GetTypeNamesFromStatList(CONST struct StatementList *sl){
-  register unsigned long len,c;
-  register CONST struct gl_list_t *l=NULL;
+  unsigned long len,c;
+  CONST struct gl_list_t *l=NULL;
   struct gl_list_t *found=NULL;
   struct Statement *s=NULL;
   symchar *td;
@@ -624,8 +624,8 @@ void WriteStatement(FILE *f, CONST struct Statement *s, int i){
  * SELECT, the nested SELECTs do not require it.
  */
 void WriteStatementList(FILE *f, CONST struct StatementList *sl, int i){
-  register unsigned long len,c;
-  register CONST struct gl_list_t *l;
+  unsigned long len,c;
+  CONST struct gl_list_t *l;
   struct Statement *stat;
   l = GetList(sl);
   len = gl_length(l);
@@ -645,8 +645,8 @@ void WriteStatementList(FILE *f, CONST struct StatementList *sl, int i){
 void WriteDiffStatementList(FILE *f, CONST struct StatementList *sl1,
                             CONST struct StatementList *sl2, int i
 ){
-  register unsigned long len1,len2,c;
-  register CONST struct gl_list_t *l;
+  unsigned long len1,len2,c;
+  CONST struct gl_list_t *l;
   struct Statement *stat;
   l = GetList(sl1);
   len1=gl_length(l);

--- a/ascend/compiler/switch.c
+++ b/ascend/compiler/switch.c
@@ -38,7 +38,7 @@
 
 struct SwitchList *CreateSwitch(struct Set *set, struct StatementList *sl)
 {
-  register struct SwitchList *result;
+  struct SwitchList *result;
   SWMALLOC(result);
   result->slist = sl;
   result->values =set;
@@ -48,7 +48,7 @@ struct SwitchList *CreateSwitch(struct Set *set, struct StatementList *sl)
 
 struct SwitchList *ReverseSwitchCases(struct SwitchList *sw)
 {
-  register struct SwitchList *next,*previous=NULL;
+  struct SwitchList *next,*previous=NULL;
   if (sw==NULL) return sw;
   while (1) {			/* loop until broken */
     next = sw->next;
@@ -62,7 +62,7 @@ struct SwitchList *ReverseSwitchCases(struct SwitchList *sw)
 struct SwitchList *LinkSwitchCases(struct SwitchList *sw1,
 				   struct SwitchList *sw2)
 {
-  register struct SwitchList *p;
+  struct SwitchList *p;
   p = sw1;
   while (p->next!=NULL) p = p->next;
   p->next = sw2;
@@ -91,7 +91,7 @@ struct StatementList *SwitchStatementListF(struct SwitchList *sw)
 
 void DestroySwitchNode(struct SwitchList *sw)
 {
-  register struct Set *set;
+  struct Set *set;
   if (sw!=NULL){
     set = sw->values;
     if (sw->values) {
@@ -110,7 +110,7 @@ void DestroySwitchNode(struct SwitchList *sw)
 
 void DestroySwitchList(struct SwitchList *sw)
 {
-  register struct SwitchList *next;
+  struct SwitchList *next;
   while (sw!=NULL){
     next = NextSwitchCase(sw);
     DestroySwitchNode(sw);
@@ -120,7 +120,7 @@ void DestroySwitchList(struct SwitchList *sw)
 
 struct SwitchList *CopySwitchNode(struct SwitchList *sw)
 {
-  register struct SwitchList *result;
+  struct SwitchList *result;
   assert(sw);
   SWMALLOC(result);
   if (sw->values) result->values = CopySetByReference(sw->values);
@@ -132,7 +132,7 @@ struct SwitchList *CopySwitchNode(struct SwitchList *sw)
 
 struct SwitchList *CopySwitchList(struct SwitchList *sw)
 {
-  register struct SwitchList *head=NULL,*p;
+  struct SwitchList *head=NULL,*p;
   if (sw!=NULL) {
     p = head = CopySwitchNode(sw);
     sw = sw->next;

--- a/ascend/compiler/symtab.c
+++ b/ascend/compiler/symtab.c
@@ -110,9 +110,9 @@ in string space.
 \*********************************************************************/
 static symchar *CopyString(CONST char *str,int userlen)
 {
-  register unsigned long length;
-  register struct StringSpaceRec *ptr;
-  register char *result;
+  unsigned long length;
+  struct StringSpaceRec *ptr;
+  char *result;
   int *lenptr;
   assert(userlen == (int)strlen(str));
   length = (unsigned long)userlen+1;
@@ -162,7 +162,7 @@ static symchar *CopyString(CONST char *str,int userlen)
 
 void DestroyStringSpace(void)
 {
-  register struct StringSpaceRec *ptr,*next;
+  struct StringSpaceRec *ptr,*next;
   ptr = g_string_space;
   while (ptr != NULL){
     next = ptr->next;
@@ -178,8 +178,8 @@ void DestroyStringSpace(void)
 
 static void StringSpaceReport(FILE *fp)
 {
-  register unsigned long num_blocks=0,used_memory=0;
-  register struct StringSpaceRec *ptr;
+  unsigned long num_blocks=0,used_memory=0;
+  struct StringSpaceRec *ptr;
   ptr = g_string_space;
   while(ptr != NULL){
     num_blocks++;
@@ -203,7 +203,7 @@ static void StringSpaceReport(FILE *fp)
 
 void InitSymbolTable(void)
 {
-  register int c;
+  int c;
   for(c=0;c<SYMTABSIZE;g_symbol_table[c++]=NULL);
   g_symbol_size = 0;
   g_symbol_collisions = 0;
@@ -216,9 +216,9 @@ void InitSymbolTable(void)
 
 symchar *AddSymbolL(CONST char *c, int l)
 {
-  register unsigned long hv;
-  register int cmp;
-  register struct symbol_entry *item,*next;
+  unsigned long hv;
+  int cmp;
+  struct symbol_entry *item,*next;
   hv = SymHashFunction(c);
   if (l<=0) l = strlen(c);
   if (g_symbol_table[hv]==NULL) {
@@ -266,8 +266,8 @@ symchar *AddSymbol(CONST char *c)
  */
 symchar *AscFindSymbol(symchar *c)
 {
-  register unsigned long hv;
-  register struct symbol_entry *next;
+  unsigned long hv;
+  struct symbol_entry *next;
 
   hv = SymHashFunction(c);
   for (next = g_symbol_table[hv]; next != NULL; next = next->next) {

--- a/ascend/compiler/syntax.c
+++ b/ascend/compiler/syntax.c
@@ -38,7 +38,7 @@
 
 unsigned NumberOfRelOps(struct Expr *ex)
 {
-  register unsigned count=0;
+  unsigned count=0;
   while(ex!=NULL){
     switch(ExprType(ex)){
     case e_equal:

--- a/ascend/compiler/type_desc.c
+++ b/ascend/compiler/type_desc.c
@@ -244,8 +244,8 @@ void UnLinkTypeDesc(struct TypeDescription *old,
  */
 static
 unsigned short int StatListHasDefaults(struct StatementList *sl) {
-  register unsigned long len,c;
-  register CONST struct gl_list_t *l;
+  unsigned long len,c;
+  CONST struct gl_list_t *l;
 
   len = StatementListLength(sl);
   if (len==0L) return 0;
@@ -293,8 +293,8 @@ int ParametersInTypeInsideSelect(struct Statement *stat)
 static
 unsigned short int ParametersInType(struct StatementList *sl,
                                     struct StatementList *psl) {
-  register unsigned long len,c;
-  register CONST struct gl_list_t *l;
+  unsigned long len,c;
+  CONST struct gl_list_t *l;
   struct TypeDescription *d;
   struct Statement *stat;
   unsigned int forflags = (contains_ISA | contains_WILLBE | contains_IRT );
@@ -403,7 +403,7 @@ struct TypeDescription
 		struct StatementList *tsl, /* list of reduced statements */
 		struct StatementList *wsl  /* list of wbts statements */
 ){
-  register struct TypeDescription *result;
+  struct TypeDescription *result;
   result=ASC_NEW(struct TypeDescription);
   result->ref_count = 1;
   result->t = model_type;
@@ -438,7 +438,7 @@ struct TypeDescription
 struct TypeDescription
 *CreateDummyTypeDesc(symchar *name)
 {
-  register struct TypeDescription *result;
+  struct TypeDescription *result;
   result=ASC_NEW(struct TypeDescription);
   result->ref_count = 1;
   result->t = dummy_type;
@@ -469,7 +469,7 @@ struct TypeDescription *CreateConstantTypeDesc(
 		symchar *sval,          /* default symbol */
 		int univ
 ){
-  register struct TypeDescription *result;
+  struct TypeDescription *result;
   result=ASC_NEW(struct TypeDescription);
   result->t = t;
   result->ref_count = 1;
@@ -526,7 +526,7 @@ struct TypeDescription
 		long ival,
 		symchar *sval
 ){
-  register struct TypeDescription *result;
+  struct TypeDescription *result;
   result=ASC_NEW(struct TypeDescription);
 #if TYPELINKDEBUG
   FPRINTF(ASCERR,"\n");
@@ -632,7 +632,7 @@ struct TypeDescription *FindArray(struct module_t *mod,
 		int iswhen,
 		struct gl_list_t *indices
 ){
-  register struct ArrayDescList *ptr;
+  struct ArrayDescList *ptr;
   int ade;
   ptr = g_array_desc_list;
   while(ptr!=NULL){
@@ -650,7 +650,7 @@ struct TypeDescription *FindArray(struct module_t *mod,
 
 static
 void AddArray(struct TypeDescription *d){
-  register struct ArrayDescList *ptr;
+  struct ArrayDescList *ptr;
   ptr = g_array_desc_list;
   g_array_desc_list =
     (struct ArrayDescList *)ascmalloc(sizeof(struct ArrayDescList));
@@ -660,7 +660,7 @@ void AddArray(struct TypeDescription *d){
 
 static
 void RemoveArrayTypeDesc(struct TypeDescription *d){
-  register struct ArrayDescList *ptr , *next;
+  struct ArrayDescList *ptr , *next;
   ptr = g_array_desc_list;
   if (ptr!=NULL){
     if (ptr->desc == d){
@@ -691,7 +691,7 @@ struct TypeDescription *CreateArrayTypeDesc(struct module_t *mod,
 		int iswhen,
 		struct gl_list_t *indices
 ){
-  register struct TypeDescription *result;
+  struct TypeDescription *result;
 #if MAKEARRAYNAMES
   char name[64];
 #endif
@@ -829,7 +829,7 @@ struct TypeDescription
 		     struct gl_list_t *pl,	/* procedures */
 		     struct StatementList *sl 	/* declarative */
 ){
-  register struct TypeDescription *result;
+  struct TypeDescription *result;
   assert(rdesc!=NULL);			/* mandatory */
   result=ASC_NEW(struct TypeDescription);
   result->ref_count = 1;
@@ -855,7 +855,7 @@ struct TypeDescription
 struct TypeDescription *MoreRefined(CONST struct TypeDescription *desc1,
 				    CONST struct TypeDescription *desc2)
 {
-  register CONST struct TypeDescription *ptr1,*ptr2;
+  CONST struct TypeDescription *ptr1,*ptr2;
   AssertAllocatedMemory(desc1,sizeof(struct TypeDescription));
   AssertAllocatedMemory(desc2,sizeof(struct TypeDescription));
   if (desc1->t!=desc2->t) return NULL; /* base types unequal */
@@ -1573,7 +1573,7 @@ int TypesAreEquivalent(CONST struct TypeDescription *d1,
 void DifferentVersionCheck(CONST struct TypeDescription *desc1,
 			   CONST struct TypeDescription *desc2
 ){
-  register CONST struct TypeDescription *ptr;
+  CONST struct TypeDescription *ptr;
   int erred;
   erred = 0;
   AssertAllocatedMemory(desc1,sizeof(struct TypeDescription));

--- a/ascend/compiler/typedef.c
+++ b/ascend/compiler/typedef.c
@@ -550,7 +550,7 @@ DoNameF(CONST struct Name *nptr,
         CONST struct Statement *stat,
         int noisy)
 {
-  register symchar *name;
+  symchar *name;
   int ok;
   int nsubs=0;
 
@@ -627,7 +627,7 @@ enum typelinterr DoVarList(CONST struct VariableList *vlist,
                            CONST struct TypeDescription *type,
                            CONST struct Statement *stat)
 {
-  register CONST struct Name *nptr;
+  CONST struct Name *nptr;
   enum typelinterr error_code;
   while(vlist!=NULL){
     nptr = NamePointer(vlist);
@@ -675,8 +675,8 @@ static
 enum typelinterr VerifyALIASES(CONST struct StatementList *stats,
                            struct gl_list_t *childlist)
 {
-  register struct gl_list_t *statements;
-  register unsigned long c,len,pos;
+  struct gl_list_t *statements;
+  unsigned long c,len,pos;
   enum typelinterr error_code;
   struct Statement *stat;
   struct ChildListEntry test;
@@ -753,8 +753,8 @@ enum typelinterr VerifyALIASES(CONST struct StatementList *stats,
 static
 enum typelinterr DoIS_A(CONST struct StatementList *stats)
 {
-  register struct gl_list_t *statements;
-  register unsigned long c,len;
+  struct gl_list_t *statements;
+  unsigned long c,len;
   enum typelinterr error_code;
   struct Statement *stat;
   statements = GetList(stats);
@@ -1157,9 +1157,9 @@ enum typelinterr DoRelations(symchar *type,
         	             CONST struct StatementList *stats,
         	             struct gl_list_t *ft)
 {
-  register struct gl_list_t *statements;
-  register unsigned long c,len;
-  register struct Statement *stat;
+  struct gl_list_t *statements;
+  unsigned long c,len;
+  struct Statement *stat;
   enum typelinterr error_code;
   statements = GetList(stats);
   len = gl_length(statements);
@@ -1240,9 +1240,9 @@ enum typelinterr DoWhens(symchar *type,
                          CONST struct StatementList *stats,
                          struct gl_list_t *ft)
 {
-  register struct gl_list_t *statements;
-  register unsigned long c,len;
-  register struct Statement *stat;
+  struct gl_list_t *statements;
+  unsigned long c,len;
+  struct Statement *stat;
   enum typelinterr error_code;
   statements = GetList(stats);
   len = gl_length(statements);
@@ -1373,7 +1373,7 @@ struct AliasList *ALPrepend(struct AliasList *list, struct AliasList *ele)
 static
 struct AliasList *CreateAliasesList(struct StatementList *stats)
 {
-  register struct Statement *stat;
+  struct Statement *stat;
   struct gl_list_t *statements;
   struct AliasList *result=NULL;
   unsigned long c,len;
@@ -2558,9 +2558,9 @@ enum typelinterr VerifyDefsAsgns(symchar *name,
                                  struct gl_list_t *lclgl,
                                  struct gl_list_t *ft)
 {
-  register struct gl_list_t *statements;
-  register unsigned long c,len;
-  register unsigned long nc,nlen;
+  struct gl_list_t *statements;
+  unsigned long c,len;
+  unsigned long nc,nlen;
   CONST struct TypeDescription *rtype;
   struct Statement *stat;
   CONST struct Name *nptr;
@@ -2744,8 +2744,8 @@ static
 enum typelinterr VerifyRefinementLegal(CONST struct StatementList *stats,
                                        struct gl_list_t *lclgl)
 {
-  register unsigned long c,len,pos;
-  register struct gl_list_t *statements;
+  unsigned long c,len,pos;
+  struct gl_list_t *statements;
   CONST struct VariableList *vl;
   struct Statement *stat;
   CONST struct Name *nptr;
@@ -3197,7 +3197,7 @@ enum typelinterr VerifyISAARGS(CONST struct StatementList *stats,
                                struct gl_list_t *lclgl,
                                struct gl_list_t *ft)
 {
-  register unsigned long c,len;
+  unsigned long c,len;
   struct Statement *stat;
   CONST struct Set *alist;
   CONST struct TypeDescription *d;
@@ -3254,7 +3254,7 @@ enum typelinterr VerifyForVars(CONST struct StatementList *stats,
                                struct gl_list_t *ft,
                                symchar *name)
 {
-  register unsigned long c,len,nc,nlen;
+  unsigned long c,len,nc,nlen;
   struct Statement *stat;
   symchar *fvname;
   unsigned long pos;
@@ -3534,9 +3534,9 @@ enum typelinterr VerifyRelationNames(symchar * name,
                                      struct gl_list_t *lclgl,
                                      struct gl_list_t *ft)
 {
-  register struct gl_list_t *statements;
-  register unsigned long c,len;
-  register struct Statement *stat;
+  struct gl_list_t *statements;
+  unsigned long c,len;
+  struct Statement *stat;
   enum typelinterr error_code;
   statements = GetList(stats);
   len = gl_length(statements);
@@ -3858,7 +3858,7 @@ enum typelinterr DoParamName(CONST struct Name *nptr,
         		     CONST struct Statement *stat,
                              int checksubs)
 {
-  register symchar *name;
+  symchar *name;
   int isarray =0;
   int ok;
   if (NameId(nptr)){
@@ -3906,7 +3906,7 @@ enum typelinterr DoParamVarList(CONST struct VariableList *vlist,
                            CONST struct Statement *stat,
                            int checksubs)
 {
-  register CONST struct Name *nptr;
+  CONST struct Name *nptr;
   enum typelinterr error_code;
 
   while(vlist!=NULL){
@@ -3935,8 +3935,8 @@ enum typelinterr ParametricChildList(symchar *name,
                                      struct StatementList *slist,
                                      int checksubs)
 {
-  register struct gl_list_t *statements;
-  register unsigned long c,len;
+  struct gl_list_t *statements;
+  unsigned long c,len;
   enum typelinterr error_code;
   struct Statement *stat;
 
@@ -3990,8 +3990,8 @@ enum typelinterr CheckParameterWheres(symchar *name,
                                       struct StatementList *slist,
                                       struct gl_list_t *lclgl)
 {
-  register struct gl_list_t *statements;
-  register unsigned long c,len;
+  struct gl_list_t *statements;
+  unsigned long c,len;
   struct Statement *stat;
   CONST struct VariableList *vl;
   CONST struct TypeDescription *rtype;
@@ -4556,7 +4556,7 @@ static
 ChildListPtr FinishChildList(symchar *type, struct StatementList *stats)
 {
   ChildListPtr result;
-  register struct gl_list_t *childlist;
+  struct gl_list_t *childlist;
   struct gl_list_t *ilist;
   struct for_table_t *ftable;
   enum typelinterr error_code;
@@ -4991,10 +4991,10 @@ struct TypeDescription *CreateModelTypeDef(symchar *name,
 static
 ChildListPtr MakeAtomChildList(struct StatementList *sl)
 {
-  register struct Statement *stat;
+  struct Statement *stat;
   ChildListPtr result;
-  register struct gl_list_t *list,*childlist;
-  register unsigned long c,len;
+  struct gl_list_t *list,*childlist;
+  unsigned long c,len;
   enum typelinterr error_code;
   list = GetList(sl);
   len = gl_length(list);
@@ -5132,7 +5132,7 @@ struct TypeDescription *CreateAtomTypeDef(symchar *name,
   struct TypeDescription *rdesc;
   ChildListPtr clist;
   struct ChildDesc *childd;
-  register unsigned long bytesize;
+  unsigned long bytesize;
 
   if (err) {
     ERROR_REPORTER_NOLINE(ASC_PROG_ERR,"Atom definition \"%s\" abandoned due to syntax errors.",SCP(name));

--- a/ascend/compiler/units.c
+++ b/ascend/compiler/units.c
@@ -83,9 +83,9 @@ static struct ParseReturn ParseString(CONST char *c
 );
 
 
-static void CopyToGlobal(register CONST char *c){
-  register char *p;
-  register unsigned length;
+static void CopyToGlobal(CONST char *c){
+  char *p;
+  unsigned length;
   length = strlen(c);
   if (g_units_str==NULL) {
     g_units_str = ascmalloc((unsigned)length+(unsigned)1);
@@ -137,8 +137,8 @@ static char *g_unit_base_name[NUM_DIMENS];
 
 
 void InitUnitsTable(void){
-  register unsigned long c;
-  //register CONST struct Units *result;
+  unsigned long c;
+  //CONST struct Units *result;
 
   for(c=0;c<UNITS_HASH_SIZE;g_units_hash_table[c++]=NULL);
     /* no body */
@@ -161,7 +161,7 @@ void InitUnitsTable(void){
 
 
 void DestroyUnitsTable(void){
-  register unsigned long c;
+  unsigned long c;
   struct Units *ptr,*next;
   for(c=0;c<UNITS_HASH_SIZE;g_units_hash_table[c++]=NULL){
     next = g_units_hash_table[c];
@@ -266,8 +266,8 @@ void ProcessUnitDef(struct UnitDefinition *ud){
 
 
 CONST struct Units *LookupUnits(CONST char *c){
-  register struct Units *result;
-  register int str_cmp=1;
+  struct Units *result;
+  int str_cmp=1;
   if((result=g_units_hash_table[UnitsHashFunction(c)])!=NULL) {
     while(((str_cmp=strcmp(SCP(UnitsDescription(result)),c))<0) &&
 	  (result->next != NULL))
@@ -292,9 +292,9 @@ static struct Units *CheckUnitsMatch(struct Units *p
 CONST struct Units *DefineUnits(symchar *c
 	, double conv, CONST dim_type *dim
 ){
-  register unsigned long bucket;
-  register struct Units *result,*tmp;
-  register int str_cmp;
+  unsigned long bucket;
+  struct Units *result,*tmp;
+  int str_cmp;
   assert(AscFindSymbol(c)!=NULL);
   bucket=UnitsHashFunction(SCP(c));
   if(g_units_hash_table[bucket]!=NULL){
@@ -342,7 +342,7 @@ static void SkipStrBlanks(CONST char *c, unsigned long int *CONST pos){
 }
 
 
-static int AddChar(register char ch, register unsigned int pos){
+static int AddChar(char ch, unsigned int pos){
   if (pos < MAXTOKENLENGTH) {
     g_units_id_space[pos]=ch;
     return 1;
@@ -355,7 +355,7 @@ static int AddChar(register char ch, register unsigned int pos){
 static enum units_scanner_tokens GetUnitsToken(CONST char *c
 	, unsigned long int *CONST pos
 ){
-  register unsigned cc;
+  unsigned cc;
   SkipStrBlanks(c,pos);
 
 #define ADD_CHAR_S \
@@ -459,7 +459,7 @@ static
 FRACPART ParseInt(CONST char *c,
 	unsigned long int *CONST pos, int *CONST error_code
 ){
-  register unsigned count=0;
+  unsigned count=0;
   SkipStrBlanks(c,pos);
   if((c[*pos]=='-')||(c[*pos]=='+'))
     g_units_id_space[count++]=c[(*pos)++];
@@ -484,7 +484,7 @@ static
 struct fraction ParseFraction(CONST char *c,
 	unsigned long int *CONST pos, int *CONST error_code
 ){
-  register FRACPART num,denom;
+  FRACPART num,denom;
   SkipStrBlanks(c,pos);
   if(c[*pos]=='('){
     MSG("Got '('");
@@ -540,7 +540,7 @@ static
 struct ParseReturn ParseTerm(CONST char *c,
 	unsigned long int *CONST pos, int *CONST error_code
 ){
-  register CONST struct Units *lookup;
+  CONST struct Units *lookup;
   struct fraction frac;
   //enum units_scanner_tokens tok;
   struct ParseReturn result;
@@ -724,7 +724,7 @@ struct ParseReturn CheckNewUnits(CONST char *c
     ,unsigned long int *CONST pos, int *CONST error_code
 ){
   struct ParseReturn preturn;
-  register CONST struct Units *result;
+  CONST struct Units *result;
 
   /* initialize return codes */
   *pos = 0;
@@ -747,7 +747,7 @@ struct ParseReturn CheckNewUnits(CONST char *c
 CONST struct Units *FindOrDefineUnits(CONST char *c,
 		unsigned long int *CONST pos, int *CONST error_code
 ){
-  register CONST struct Units *result;
+  CONST struct Units *result;
   struct ParseReturn preturn;
 
   /* initialize return codes */
@@ -827,8 +827,8 @@ char *UnitsStringSI(const struct Units *p){
 
 
 void DumpUnits(FILE *file){
-  register unsigned long c;
-  register struct Units *p;
+  unsigned long c;
+  struct Units *p;
   char *ds;
   FPRINTF(file,"Units dump\n");
   for(c=0;c<UNITS_HASH_SIZE;c++) {

--- a/ascend/compiler/universal.c
+++ b/ascend/compiler/universal.c
@@ -85,8 +85,8 @@ struct UniversalTable *GetUniversalTable(void)
 struct Instance *LookupInstance(struct gl_list_t *table,
 				struct TypeDescription *desc)
 {
-  register unsigned long c;
-  register struct universal_rec *ptr;
+  unsigned long c;
+  struct universal_rec *ptr;
   if (table){
     for(c=gl_length(table);c>=1;--c){
       ptr = (struct universal_rec *)gl_fetch(table,c);
@@ -113,8 +113,8 @@ void AddUniversalInstance(struct gl_list_t *table,
 
 void RemoveUniversalInstance(struct gl_list_t *table, struct Instance *inst)
 {
-  register unsigned long c;
-  register struct universal_rec *ptr;
+  unsigned long c;
+  struct universal_rec *ptr;
   if (table){
     for(c=gl_length(table);c>=1;--c){
       ptr = (struct universal_rec *)gl_fetch(table,c);
@@ -131,8 +131,8 @@ void ChangeUniversalInstance(struct gl_list_t *table,
 			     struct Instance *oldinst,
 			     struct Instance *newinst)
 {
-  register unsigned long c;
-  register struct universal_rec *ptr;
+  unsigned long c;
+  struct universal_rec *ptr;
   if (table){
     for(c=gl_length(table);c>=1;--c){
       ptr = (struct universal_rec *)gl_fetch(table,c);
@@ -155,7 +155,7 @@ unsigned long NumberTypes(struct gl_list_t *table)
 
 struct Instance *GetInstance(struct gl_list_t *table, unsigned long int pos)
 {
-  register struct universal_rec *ptr;
+  struct universal_rec *ptr;
   if (table){
     ptr = (struct universal_rec *)gl_fetch(table,pos);
     AssertAllocatedMemory(ptr,sizeof(struct universal_rec));
@@ -168,7 +168,7 @@ struct Instance *GetInstance(struct gl_list_t *table, unsigned long int pos)
 struct TypeDescription *GetTypeDescription(struct gl_list_t *table,
 					   unsigned long int pos)
 {
-  register struct universal_rec *ptr;
+  struct universal_rec *ptr;
   if (table){
     ptr = (struct universal_rec *)gl_fetch(table,pos);
     AssertAllocatedMemory(ptr,sizeof(struct universal_rec));

--- a/ascend/compiler/value_type.c
+++ b/ascend/compiler/value_type.c
@@ -171,10 +171,10 @@ struct value_t CreateSetValue(struct set_t *sptr)
 struct value_t CreateSetFromList(struct value_t value)
 {
   struct value_t result;
-  register struct value_t *vptr;
-  register struct set_t *sptr,*tmp;
-  register struct gl_list_t *list;
-  register unsigned long c,len;
+  struct value_t *vptr;
+  struct set_t *sptr,*tmp;
+  struct gl_list_t *list;
+  unsigned long c,len;
   IVAL(result);
   if (value.t == error_value) return value;
   result.t = set_value;
@@ -253,11 +253,11 @@ struct value_t CreateSetFromList(struct value_t value)
 struct value_t CreateOrderedSetFromList(struct value_t value)
 {
   struct value_t result;
-  register struct value_t *vptr;
-  register struct set_t *sptr;
+  struct value_t *vptr;
+  struct set_t *sptr;
   struct set_t *sval;
-  register struct gl_list_t *list;
-  register unsigned long c,len, sc,slen;
+  struct gl_list_t *list;
+  unsigned long c,len, sc,slen;
   IVAL(result);
 
   assert(ListMode!=0);
@@ -732,7 +732,7 @@ struct value_t DivideValues(struct value_t value1, struct value_t value2)
 static
 long ipower(long int x, long int y)
 {
-  register long result=1;
+  long result=1;
   if (y==0) return result;
   if (y>0) {
     while(y-->0)

--- a/ascend/compiler/vlist.c
+++ b/ascend/compiler/vlist.c
@@ -45,7 +45,7 @@
 
 struct VariableList *CreateVariableNode(struct Name *n)
 {
-  register struct VariableList *result;
+  struct VariableList *result;
   assert(n!=NULL);
   result = NLMALLOC;
   assert(result!=NULL);
@@ -74,7 +74,7 @@ CONST struct Name *NamePointerF(CONST struct VariableList *n)
 
 struct VariableList *CopyVariableList(struct VariableList *n)
 {
-  register struct VariableList *result,*p,*np;
+  struct VariableList *result,*p,*np;
   if (n==NULL) return NULL;
   np = n;
   result = NLMALLOC;
@@ -100,9 +100,9 @@ unsigned long VariableListLength(CONST struct VariableList *n)
   return len;
 }
 
-void DestroyVariableList(register struct VariableList *n)
+void DestroyVariableList(struct VariableList *n)
 {
-  register struct VariableList *next;
+  struct VariableList *next;
   while (n!=NULL) {
     next = n->next;
     DestroyName(n->nptr);
@@ -122,7 +122,7 @@ void DestroyVariableListNode(struct VariableList *n)
 struct VariableList *JoinVariableLists(struct VariableList *n1,
 				       struct VariableList *n2)
 {
-  register struct VariableList *p;
+  struct VariableList *p;
   if (n1==NULL) return n2;
   /* find end of name list n1 */
   p = n1;
@@ -132,9 +132,9 @@ struct VariableList *JoinVariableLists(struct VariableList *n1,
   return n1;
 }
 
-struct VariableList *ReverseVariableList(register struct VariableList *n)
+struct VariableList *ReverseVariableList(struct VariableList *n)
 {
-  register struct VariableList *next,*previous=NULL;
+  struct VariableList *next,*previous=NULL;
   if (n==NULL) return n;
   while (TRUE) {		/* loop until broken */
     next = n->next;

--- a/ascend/compiler/when.c
+++ b/ascend/compiler/when.c
@@ -56,7 +56,7 @@ int SetNodeIsTrue(struct Set *s)
 
 struct WhenList *CreateWhen(struct Set *set, struct StatementList *sl)
 {
-  register struct WhenList *result;
+  struct WhenList *result;
   WMALLOC(result);
   result->slist = sl;
   result->values =set;
@@ -66,7 +66,7 @@ struct WhenList *CreateWhen(struct Set *set, struct StatementList *sl)
 
 struct WhenList *ReverseWhenCases(struct WhenList *w)
 {
-  register struct WhenList *next,*previous=NULL;
+  struct WhenList *next,*previous=NULL;
   if (w==NULL) return w;
   while (1) {			/* loop until broken */
     next = w->next;
@@ -79,7 +79,7 @@ struct WhenList *ReverseWhenCases(struct WhenList *w)
 
 struct WhenList *LinkWhenCases(struct WhenList *w1, struct WhenList *w2)
 {
-  register struct WhenList *p;
+  struct WhenList *p;
   p = w1;
   while (p->next!=NULL) p = p->next;
   p->next = w2;
@@ -107,7 +107,7 @@ struct StatementList *WhenStatementListF(struct WhenList *w)
 
 void DestroyWhenNode(struct WhenList *w)
 {
-  register struct Set *set;
+  struct Set *set;
   if (w!=NULL){
     set = w->values;
     if (w->values) {
@@ -126,7 +126,7 @@ void DestroyWhenNode(struct WhenList *w)
 
 void DestroyWhenList(struct WhenList *w)
 {
-  register struct WhenList *next;
+  struct WhenList *next;
   while (w!=NULL){
     next = NextWhenCase(w);
     DestroyWhenNode(w);
@@ -136,7 +136,7 @@ void DestroyWhenList(struct WhenList *w)
 
 struct WhenList *CopyWhenNode(struct WhenList *w)
 {
-  register struct WhenList *result;
+  struct WhenList *result;
   assert(w!=NULL);
   WMALLOC(result);
   if (w->values) result->values = CopySetByReference(w->values);
@@ -148,7 +148,7 @@ struct WhenList *CopyWhenNode(struct WhenList *w)
 
 struct WhenList *CopyWhenList(struct WhenList *w)
 {
-  register struct WhenList *head=NULL,*p;
+  struct WhenList *head=NULL,*p;
   if (w!=NULL) {
     p = head = CopyWhenNode(w);
     w = w->next;

--- a/ascend/compiler/when_util.c
+++ b/ascend/compiler/when_util.c
@@ -207,8 +207,8 @@ struct gl_list_t *CopyWhenCaseRefList(struct Instance *dest_inst,
 
 void DestroyWhenVarList(struct gl_list_t *l, struct Instance *inst)
 {
-  register struct Instance *ptr;
-  register unsigned long c;
+  struct Instance *ptr;
+  unsigned long c;
   for(c=gl_length(l);c>=1;c--){
     if (NULL != (ptr = (struct Instance *)gl_fetch(l,c))){
       switch(ptr->t) {
@@ -232,8 +232,8 @@ void DestroyWhenVarList(struct gl_list_t *l, struct Instance *inst)
 static
 void DestroyWhenCases(struct Case *cur_case, struct Instance *inst)
 {
-  register struct Instance *ptr;
-  register unsigned long c,len;
+  struct Instance *ptr;
+  unsigned long c,len;
   struct gl_list_t *reflist;
 
   reflist = GetCaseReferences(cur_case);
@@ -261,7 +261,7 @@ void DestroyWhenCases(struct Case *cur_case, struct Instance *inst)
 void DestroyWhenCaseList(struct gl_list_t *l, struct Instance *inst)
 {
   struct Case *cur_case;
-  register unsigned long c,len;
+  unsigned long c,len;
   len = gl_length(l);
 
   for(c=len;c>=1;c--){

--- a/ascend/general/ascMalloc.c
+++ b/ascend/general/ascMalloc.c
@@ -147,7 +147,7 @@ char *ascreallocPUREF(char *ptr, size_t oldbytes, size_t newbytes){
     ret = malloc(newbytes);
     if (ret==NULL) return NULL;
     if (oldbytes%sizeof(long) == 0 && ((asc_intptr_t)ptr)%sizeof(long) == 0) {
-      register unsigned long c,len, *src, *trg;
+      unsigned long c,len, *src, *trg;
       src = (unsigned long *)ptr;
       trg = (unsigned long *)ret;
       len = oldbytes/sizeof(long);
@@ -182,7 +182,7 @@ char *ascreallocPUREF_dbg(char *ptr, size_t oldbytes, size_t newbytes){
     ret = ascmallocf(newbytes, __FILE__, __LINE__);
     if(ret==NULL) return NULL;
     if(oldbytes%sizeof(long) == 0 && ((asc_intptr_t)ptr)%sizeof(long) == 0) {
-      register unsigned long c,len, *src, *trg;
+      unsigned long c,len, *src, *trg;
       src = (unsigned long *)ptr;
       trg = (unsigned long *)ret;
       len = oldbytes/sizeof(long);

--- a/ascend/general/dstring.c
+++ b/ascend/general/dstring.c
@@ -35,7 +35,7 @@
 #include "mathmacros.h"
 
 
-void Asc_DStringInit(register Asc_DString *dsPtr)
+void Asc_DStringInit(Asc_DString *dsPtr)
 {
   asc_assert(NULL != dsPtr);
   dsPtr->string = dsPtr->staticSpace;
@@ -81,7 +81,7 @@ char *Asc_DStringSet(Asc_DString *dsPtr, CONST char *string)
 
 
 
-char *Asc_DStringAppend(register Asc_DString *dsPtr,
+char *Asc_DStringAppend(Asc_DString *dsPtr,
                         CONST char *string,
                         int length)
 {
@@ -130,7 +130,7 @@ char *Asc_DStringAppend(register Asc_DString *dsPtr,
 
 
 
-void Asc_DStringTrunc(register Asc_DString *dsPtr, int length)
+void Asc_DStringTrunc(Asc_DString *dsPtr, int length)
 {
   asc_assert(NULL != dsPtr);
 
@@ -145,7 +145,7 @@ void Asc_DStringTrunc(register Asc_DString *dsPtr, int length)
 
 
 
-void Asc_DStringFree(register Asc_DString *dsPtr)
+void Asc_DStringFree(Asc_DString *dsPtr)
 {
   asc_assert(NULL != dsPtr);
   if (dsPtr->string != dsPtr->staticSpace) {
@@ -161,7 +161,7 @@ void Asc_DStringFree(register Asc_DString *dsPtr)
 
 char *Asc_DStringResult(Asc_DString *dsPtr)
 {
-  register char *result;
+  char *result;
 
   asc_assert (NULL != dsPtr);
   result = (char *)ascmalloc(strlen(dsPtr->string)+1);

--- a/ascend/general/hashpjw.c
+++ b/ascend/general/hashpjw.c
@@ -17,11 +17,11 @@
 
 #include "config.h"
 
-unsigned long hashpjw(register CONST char *str,
-                      register unsigned long int size)
+unsigned long hashpjw(CONST char *str,
+                      unsigned long int size)
 {
-  register CONST char *p;
-  register unsigned long h=0,g;
+  CONST char *p;
+  unsigned long h=0,g;
 
   asc_assert((NULL != str) && (size > 0));
 
@@ -42,7 +42,7 @@ unsigned long hashpjw(register CONST char *str,
  * integer hashing function.
  */
 unsigned long hashpjw_int(int id,
-                          register unsigned long int size)
+                          unsigned long int size)
 {
   char tmp[64];
 

--- a/ascend/general/list.c
+++ b/ascend/general/list.c
@@ -466,7 +466,7 @@ void gl_append_ptr(struct gl_list_t *list, VOIDPTR ptr){
 
 
 void gl_append_list(struct gl_list_t *extendlist, struct gl_list_t *list){
-  register unsigned long c,len,oldlen,newlen;
+  unsigned long c,len,oldlen,newlen;
 
   asc_assert((NULL != extendlist) &&
              (0 != gl_expandable(extendlist)) &&
@@ -642,7 +642,7 @@ void gl_upsort(struct gl_list_t *list,
                unsigned long int lower,
                unsigned long int upper)
 {
-  register unsigned long i,j;
+  unsigned long i,j;
   VOIDPTR pivot_element;
   j = upper;
   i = lower;
@@ -651,7 +651,7 @@ void gl_upsort(struct gl_list_t *list,
     while (pivot_element > gl_fetch(list,i)) i += 1;
     while (gl_fetch(list,j) > pivot_element)  j -= 1;
     if (i <= j) {
-      register VOIDPTR temp;
+      VOIDPTR temp;
       temp = gl_fetch(list,i);
       GL_STORE(list,i,gl_fetch(list,j));
       GL_STORE(list,j,temp);
@@ -741,7 +741,7 @@ void gl_insert_sorted(struct gl_list_t *list
 	, VOIDPTR ptr, CmpFunc func
 ){
   int comparison;
-  register unsigned long lower,upper,search=0L;
+  unsigned long lower,upper,search=0L;
 
   asc_assert((NULL != list) &&
              (0 != gl_expandable(list)) &&
@@ -793,7 +793,7 @@ void gl_insert_sorted(struct gl_list_t *list
 
 void gl_iterate(struct gl_list_t *list, void (*func) (VOIDPTR)){
 #ifdef NDEBUG
-  register unsigned long length,counter;
+  unsigned long length,counter;
   length = GL_LENGTH(list);
   for (counter=0;counter<length;counter++)
     (*func)(list->data[counter]);
@@ -821,7 +821,7 @@ unsigned long gl_ptr_search(CONST struct gl_list_t *list
   /* if list is short, use linear instead of binary search.
   SHORTSEARCH is the minimum size for a binary search.
   SHORTSEARCH must be >=0 */
-  register unsigned long lower,upper,search;
+  unsigned long lower,upper,search;
 
   asc_assert(NULL != list);
   if(!GL_LENGTH(list))return 0;
@@ -830,7 +830,7 @@ unsigned long gl_ptr_search(CONST struct gl_list_t *list
        && (upper = GL_LENGTH(list)-1) > SHORTSEARCH
 #endif
   ){		/* use binary search */
-    register long comparison;
+    long comparison;
     lower = 0;
 #if (SHORTSEARCH <= 0)
     upper = GL_LENGTH(list)-1;
@@ -889,7 +889,7 @@ unsigned long gl_ptr_search(CONST struct gl_list_t *list
 unsigned long gl_search(CONST struct gl_list_t *list
 	,CONST VOIDPTR match, CmpFunc func
 ){
-  register unsigned long lower,upper,search;
+  unsigned long lower,upper,search;
 #ifdef __alpha
   long comparison;
 #else
@@ -919,7 +919,7 @@ unsigned long gl_search(CONST struct gl_list_t *list
 unsigned long gl_search_reverse(CONST struct gl_list_t *list
 	,CONST VOIDPTR match, CmpFunc func
 ){
-  register unsigned long search;
+  unsigned long search;
 
   asc_assert((NULL != list) && (NULL != func));
   if(list->flags & gsf_SORTED) {	/* use binary search */
@@ -1072,7 +1072,7 @@ struct gl_list_t *gl_concat(CONST struct gl_list_t *list1
 
 int gl_compare_ptrs(CONST struct gl_list_t *l1, CONST struct gl_list_t *l2){
   unsigned long len,c;
-  register unsigned long i1,i2;
+  unsigned long i1,i2;
   if (l1==NULL || l2 == NULL) {
     ASC_PANIC("Called with NULL input");
   }

--- a/ascend/general/pool.c
+++ b/ascend/general/pool.c
@@ -470,7 +470,7 @@ pool_store_t pool_create_store(int length, int width,
 
 void *pool_get_element(pool_store_t ps){
   /* no automatic variables please */
-  register struct pool_element *elt;
+  struct pool_element *elt;
   /* in a test on the alpha, though, making elt static global slowed it */
 
   if (ISNULL(ps)) {
@@ -537,7 +537,7 @@ void pool_free_elementF(pool_store_t ps, void *ptr
 	, CONST char *fn
 #endif
 ){
-  register struct pool_element *elt;
+  struct pool_element *elt;
 
   if (ISNULL(ptr)) return;
   elt = (struct pool_element *)ptr;
@@ -712,7 +712,7 @@ void pool_print_store(FILE *fp, pool_store_t ps, unsigned detail){
 
 
 size_t pool_sizeof_store(pool_store_t ps){
-  register size_t siz;
+  size_t siz;
   if (check_pool_store(ps)>1) return (size_t)0;
   siz = sizeof(struct pool_store_header);    /* header */
   siz += ps->barsize * ps->len;             /* elt data */

--- a/ascend/linear/linsolqr.c
+++ b/ascend/linear/linsolqr.c
@@ -864,7 +864,7 @@ int32 find_pivot_number(const real64 *vec,
     return 0;
   }
   if (tol >= D_ONE) {
-    register real64 biggest = MAX(eps,D_ZERO);
+    real64 biggest = MAX(eps,D_ZERO);
     /* get the biggest, period */
     k = 0;
     for (j=0; j < len; j++) {
@@ -881,7 +881,7 @@ int32 find_pivot_number(const real64 *vec,
     ivec[0] = 0;
     if (*maxi==len) {
       /* cheap search against eps and tol, no list. */
-      register real64 thold;
+      real64 thold;
       thold = tol * vec[len-1];
       if (thold >= eps) {
         for (k = 0; k < len && vec[k] < thold; k++);
@@ -906,7 +906,7 @@ int32 find_pivot_number(const real64 *vec,
       if (bigi == 0) {
         *maxi = k = 0;
       } else {
-        register real64 thold;
+        real64 thold;
         /* Note: if bigi is enormous, we should do a binary search,
            not linear. */
         *maxi = ivec[bigi-1];
@@ -2662,7 +2662,7 @@ static void qr_forward_eliminate(linsolqr_system_t sys,
     /* arr is indexed by original column number */
     int32 dotlim,col;
     real64 *diag;
-    register int32 org_col;
+    int32 org_col;
 
     diag=sys->qrdata->alpha;
     dot_rng.low= sys->rng.low;

--- a/ascend/linear/mtx_basic.c
+++ b/ascend/linear/mtx_basic.c
@@ -1202,7 +1202,7 @@ void mtx_clear(mtx_matrix_t mtx){
 
 real64 mtx_value(mtx_matrix_t mtx, mtx_coord_t *coord){
    struct element_t *elt;
-   register int32 org_row,org_col;
+   int32 org_row,org_col;
 
 #if MTX_DEBUG
    if(!mtx_check_matrix(mtx)) return D_ZERO;
@@ -1215,7 +1215,7 @@ real64 mtx_value(mtx_matrix_t mtx, mtx_coord_t *coord){
 }
 
 void mtx_set_value( mtx_matrix_t mtx, mtx_coord_t *coord, real64 value){
-  register int32 org_row,org_col;
+  int32 org_row,org_col;
 
 #if MTX_DEBUG
   if(!mtx_check_matrix(mtx)) return;
@@ -1239,7 +1239,7 @@ void mtx_set_value( mtx_matrix_t mtx, mtx_coord_t *coord, real64 value){
 }
 
 void mtx_fill_value(mtx_matrix_t mtx, mtx_coord_t *coord, real64 value){
-   register int32 org_row,org_col;
+   int32 org_row,org_col;
 
 #if MTX_DEBUG
    if(!mtx_check_matrix(mtx)) return;
@@ -1385,7 +1385,7 @@ int32 mtx_assemble(mtx_matrix_t mtx){
 }
 
 void mtx_del_zr_in_row(mtx_matrix_t mtx, int32 row){
-   register int32 org;
+   int32 org;
    struct element_t **rlink, **clink;
 
 #if MTX_DEBUG
@@ -1407,7 +1407,7 @@ void mtx_del_zr_in_row(mtx_matrix_t mtx, int32 row){
 }
 
 void mtx_del_zr_in_col(mtx_matrix_t mtx, int32 col){
-   register int32 org;
+   int32 org;
    struct element_t **clink, **rlink;
 
 #if MTX_DEBUG
@@ -1429,7 +1429,7 @@ void mtx_del_zr_in_col(mtx_matrix_t mtx, int32 col){
 }
 
 void mtx_del_zr_in_rowrange(mtx_matrix_t mtx, mtx_range_t *rng){
-  register int32 org,row,rowhi, *toorg;
+  int32 org,row,rowhi, *toorg;
   struct element_t **rlink, **clink;
 
 #if MTX_DEBUG
@@ -1458,7 +1458,7 @@ void mtx_del_zr_in_rowrange(mtx_matrix_t mtx, mtx_range_t *rng){
 }
 
 void mtx_del_zr_in_colrange(mtx_matrix_t mtx, mtx_range_t *rng){
-  register int32 org,col,colhi, *toorg;
+  int32 org,col,colhi, *toorg;
   struct element_t **clink, **rlink;
 
 #if MTX_DEBUG
@@ -1946,8 +1946,8 @@ void mtx_fill_org_row_vec(mtx_matrix_t mtx, int32 row
 		, real64 *vec, mtx_range_t *rng
 ){
   int32 org_row,highcol, *toorg;
-  register int32 org_col;
-  register real64 value;
+  int32 org_col;
+  real64 value;
 
 #if MTX_DEBUG
   if(!mtx_check_matrix(mtx)) return;
@@ -1961,7 +1961,7 @@ void mtx_fill_org_row_vec(mtx_matrix_t mtx, int32 row
         mtx_create_element_value(mtx,org_row,org_col,value);
     }
   } else {
-    register int32 cur_col;
+    int32 cur_col;
 
     toorg = mtx->perm.col.cur_to_org;
     highcol= rng->high;
@@ -1976,8 +1976,8 @@ void mtx_fill_org_col_vec(mtx_matrix_t mtx
 		, int32 col, real64 *vec, mtx_range_t *rng
 ){
   int32 org_col,highrow, *toorg;
-  register int32 org_row;
-  register real64 value;
+  int32 org_row;
+  real64 value;
 
 #if MTX_DEBUG
   if(!mtx_check_matrix(mtx)) return;
@@ -1991,7 +1991,7 @@ void mtx_fill_org_col_vec(mtx_matrix_t mtx
         mtx_create_element_value(mtx,org_row,org_col,value);
     }
   } else {
-    register int32 cur_row;
+    int32 cur_row;
 
     toorg = mtx->perm.row.cur_to_org;
     highrow= rng->high;
@@ -2006,8 +2006,8 @@ void mtx_fill_cur_row_vec(mtx_matrix_t mtx
 		, int32 row, real64 *vec, mtx_range_t *rng
 ){
   int32 org_row,highcol,lowcol, *toorg;
-  register int32 cur_col;
-  register real64 value;
+  int32 cur_col;
+  real64 value;
 
 #if MTX_DEBUG
   if(!mtx_check_matrix(mtx)) return;
@@ -2032,8 +2032,8 @@ void mtx_fill_cur_col_vec(mtx_matrix_t mtx
 		, int32 col, real64 *vec, mtx_range_t *rng
 ){
   int32 org_col,highrow,lowrow, *toorg;
-  register int32 cur_row;
-  register real64 value;
+  int32 cur_row;
+  real64 value;
 
 #if MTX_DEBUG
   if(!mtx_check_matrix(mtx)) return;
@@ -2059,8 +2059,8 @@ void mtx_dropfill_cur_col_vec(mtx_matrix_t mtx, int32 col,
                               real64 tol
 ){
   int32 org_col,highrow,lowrow, *toorg;
-  register int32 cur_row;
-  register real64 value;
+  int32 cur_row;
+  real64 value;
 
   if (tol==0.0) {
     mtx_fill_cur_col_vec(mtx,col,vec,rng);
@@ -2091,8 +2091,8 @@ void mtx_dropfill_cur_row_vec(mtx_matrix_t mtx, int32 row,
                               real64 tol
 ){
   int32 org_row,highcol,lowcol, *toorg;
-  register int32 cur_col;
-  register real64 value;
+  int32 cur_col;
+  real64 value;
 
   if (tol==0.0) {
     mtx_fill_cur_row_vec(mtx,row,vec,rng);
@@ -2282,7 +2282,7 @@ void mtx_mult_col_zero(mtx_matrix_t mtx, int32 col, mtx_range_t *rng){
 void mtx_add_row(mtx_matrix_t mtx, int32 s_cur, int32 t_cur, real64 factor,
 		mtx_range_t *rng
 ){
-   register int32 org_col;
+   int32 org_col;
    int32 t_org,*tocur;
    struct element_t **arr,*elt;
 
@@ -2304,7 +2304,7 @@ void mtx_add_row(mtx_matrix_t mtx, int32 s_cur, int32 t_cur, real64 factor,
       }
       mtx_renull_using_row(mtx,t_org,arr);
    } else if( rng->high >= rng->low ) {
-      register int32 cur_col;
+      int32 cur_col;
 
       tocur = mtx->perm.col.org_to_cur;
       arr = mtx_expand_row(mtx,t_org);   /* Expand the target row */
@@ -2476,7 +2476,7 @@ void mtx_add_row_series_init(mtx_matrix_t mtx,int32 t_cur,boolean use){
 }
 
 void mtx_add_row_series(int32 s_cur,real64 factor,mtx_range_t *rng){
-  register int32 org_col;
+  int32 org_col;
   int32 t_org,*tocur;
   struct element_t **arr,*elt;
   mtx_matrix_t mtx;
@@ -2509,7 +2509,7 @@ void mtx_add_row_series(int32 s_cur,real64 factor,mtx_range_t *rng){
   /* fast_in_range is a 10% winner on the alpha, and should be even more
      on the other platforms. */
   if( rng->high >= rng->low ) {
-    register int32 cur_col, lo,hi;
+    int32 cur_col, lo,hi;
     lo=rng->low; hi= rng->high;
     for( ; NOTNULL(elt); elt = elt->next.col ) {
       cur_col=tocur[(org_col=elt->col)];
@@ -2566,7 +2566,7 @@ void mtx_add_col_series_init(mtx_matrix_t mtx,int32 t_cur,boolean use){
 }
 
 void mtx_add_col_series(int32 s_cur,real64 factor,mtx_range_t *rng){
-  register int32 org_row;
+  int32 org_row;
   int32 t_org,*tocur;
   struct element_t **arr,*elt;
   mtx_matrix_t mtx;
@@ -2597,7 +2597,7 @@ void mtx_add_col_series(int32 s_cur,real64 factor,mtx_range_t *rng){
     return;
   }
   if( rng->high >= rng->low ) {
-    register int32 cur_row;
+    int32 cur_row;
 
     for( ; NOTNULL(elt); elt = elt->next.row ) {
       cur_row=tocur[(org_row=elt->row)];

--- a/ascend/linear/mtx_linal.c
+++ b/ascend/linear/mtx_linal.c
@@ -180,7 +180,7 @@ void mtx_householder_transform_region(mtx_matrix_t mtx,
   struct element_t *elt;
   real64 u,mult;
   int32 ku, kr, numcols, kcol;
-  register int32 org;
+  int32 org;
 
   /* the following are reuseable buffers we must zero before releasing */
   char *mv;               /* mark buffer, should we need it, droptol */

--- a/ascend/linear/mtx_perms.c
+++ b/ascend/linear/mtx_perms.c
@@ -301,7 +301,7 @@ extern size_t mtx_block_perm_size(mtx_block_perm_t bp)
 /* DO NOT CALL this on the perm of a matrix that is a slave */
 static void swap( struct permutation_t *perm, int32 cur1,int32 cur2)
 {
-   register int32 org1,org2;
+   int32 org1,org2;
 
    if( cur1 == cur2 ) return;
    org1 = perm->cur_to_org[cur1];
@@ -343,7 +343,7 @@ void mtx_swap_cols( mtx_matrix_t mtx, int32 cur1,int32 cur2)
 
 void mtx_drag( mtx_matrix_t mtx, int32 begin, int32 end)
 {
-  register int32 *rcto, *ccto, *rotc, *cotc;
+  int32 *rcto, *ccto, *rotc, *cotc;
   int32 holdrow,holdcol;
 
 #if MTX_DEBUG
@@ -382,8 +382,8 @@ void mtx_drag( mtx_matrix_t mtx, int32 begin, int32 end)
 
 void mtx_reverse_diagonal( mtx_matrix_t mtx, int32 begin, int32 end)
 {
-  register int32 center,j;
-  register struct permutation_t *rperm, *cperm;
+  int32 center,j;
+  struct permutation_t *rperm, *cperm;
 #if MTX_DEBUG
    if(!mtx_check_matrix(mtx)) return;
 #endif
@@ -531,7 +531,7 @@ static int32 assign_row( mtx_matrix_t mtx, int32 row,
    Rewind.next.col = mtx->hdr.row[mtx->perm.row.cur_to_org[row]];
    if( NULL != (elt=mtx_next_col(&Rewind,&(vars->unassigned_cols),tocur)) ) {
       /* Cheap assignment */
-      register int32 col;
+      int32 col;
       col = tocur[elt->col];
       swap(&(mtx->perm.col),col,row);
       return(col);
@@ -542,7 +542,7 @@ static int32 assign_row( mtx_matrix_t mtx, int32 row,
       int32 col;
       col = tocur[elt->col];
       if( vars->row_visited[col] != vars->rv_indicator ) {
-         register int32 assigned_col;
+         int32 assigned_col;
          if( (assigned_col = assign_row(mtx,col,vars)) >= ZERO ) {
             swap(&(mtx->perm.col),assigned_col,row);
             return( assigned_col );

--- a/ascend/linear/mtx_query.c
+++ b/ascend/linear/mtx_query.c
@@ -738,7 +738,7 @@ int32 mtx_numbers_in_region(mtx_matrix_t mtx,mtx_region_t *reg)
   return(count);
 }
 
-static real64 msqr(register real64 d) {
+static real64 msqr(real64 d) {
   return d*d;
 }
 
@@ -758,7 +758,7 @@ void mtx_org_row_vec(mtx_matrix_t mtx, int32 row,
   }
   if( rng->high >= rng->low ) {
     int32 *tocur;
-    register int32 org_col, cur_col;
+    int32 org_col, cur_col;
     tocur = mtx->perm.col.org_to_cur;
     for( ; NOTNULL(elt); elt = elt->next.col ) {
       cur_col=tocur[(org_col = elt->col)];
@@ -784,7 +784,7 @@ void mtx_org_col_vec(mtx_matrix_t mtx, int32 col,
   }
   if( rng->high >= rng->low ) {
     int32 *tocur;
-    register int32 org_row, cur_row;
+    int32 org_row, cur_row;
     tocur = mtx->perm.row.org_to_cur;
     for( ; NOTNULL(elt); elt = elt->next.row ) {
       cur_row=tocur[(org_row = elt->row)];
@@ -811,7 +811,7 @@ void mtx_cur_row_vec(mtx_matrix_t mtx, int32 row,
     return;
   }
   if( rng->high >= rng->low ) {
-    register int32 cur_col;
+    int32 cur_col;
     for( ; NOTNULL(elt); elt = elt->next.col ) {
       cur_col=tocur[elt->col];
       if( in_range(rng,cur_col) )
@@ -837,7 +837,7 @@ void mtx_cur_col_vec(mtx_matrix_t mtx, int32 col,
     return;
   }
   if( rng->high >= rng->low ) {
-    register int32 cur_row;
+    int32 cur_row;
     for( ; NOTNULL(elt); elt = elt->next.row ) {
       cur_row=tocur[elt->row];
       if( in_range(rng,cur_row) )
@@ -886,7 +886,7 @@ mtx_sparse_t *mtx_org_row_sparse(mtx_matrix_t mtx, int32 row,
   }
   if( rng->high >= rng->low ) {
     int32 *tocur;
-    register int32 cur_col;
+    int32 cur_col;
 
     tocur = mtx->perm.col.org_to_cur;
     if (zeroes == mtx_IGNORE_ZEROES) {
@@ -961,7 +961,7 @@ mtx_sparse_t *mtx_org_col_sparse(mtx_matrix_t mtx, int32 col,
   }
   if( rng->high >= rng->low ) {
     int32 *tocur;
-    register int32 cur_row;
+    int32 cur_row;
 
     tocur = mtx->perm.row.org_to_cur;
     if (zeroes == mtx_IGNORE_ZEROES) {
@@ -1038,7 +1038,7 @@ mtx_sparse_t *mtx_cur_row_sparse(mtx_matrix_t mtx, int32 row,
   }
   /* range is not ALL */
   if( rng->high >= rng->low ) {
-    register int32 cur_col;
+    int32 cur_col;
 
     if (zeroes == mtx_IGNORE_ZEROES) {
       for(k=0; NOTNULL(elt) && k < cap; elt = elt->next.col ) {
@@ -1113,7 +1113,7 @@ mtx_sparse_t *mtx_cur_col_sparse(mtx_matrix_t mtx, int32 col,
     return NULL; /* ran out of vector */
   }
   if( rng->high >= rng->low ) {
-    register int32 cur_row;
+    int32 cur_row;
 
     if (zeroes == mtx_IGNORE_ZEROES) {
       for(k=0; NOTNULL(elt) && k < cap; elt = elt->next.row ) {
@@ -1162,7 +1162,7 @@ void mtx_zr_org_vec_using_row(mtx_matrix_t mtx,int32 row,
     return;
   }
   if( rng->high >= rng->low ) {
-    register int32 org_col, cur_col;
+    int32 org_col, cur_col;
     int32 *tocur;
     tocur = mtx->perm.col.org_to_cur;
     for( ; NOTNULL(elt); elt = elt->next.col ) {
@@ -1188,7 +1188,7 @@ void mtx_zr_org_vec_using_col(mtx_matrix_t mtx, int32 col,
     return;
   }
   if( rng->high >= rng->low ) {
-    register int32 org_row, cur_row;
+    int32 org_row, cur_row;
     int32 *tocur;
     tocur = mtx->perm.row.org_to_cur;
     for( ; NOTNULL(elt); elt = elt->next.row ) {
@@ -1216,7 +1216,7 @@ void mtx_zr_cur_vec_using_row(mtx_matrix_t mtx,int32 row,
     return;
   }
   if( rng->high >= rng->low ) {
-    register int32 cur_col;
+    int32 cur_col;
     for( ; NOTNULL(elt); elt = elt->next.col ) {
       cur_col=tocur[elt->col];
       if( in_range(rng,cur_col) )
@@ -1242,7 +1242,7 @@ void mtx_zr_cur_vec_using_col(mtx_matrix_t mtx, int32 col,
     return;
   }
   if( rng->high >= rng->low ) {
-    register int32 cur_row;
+    int32 cur_row;
     for( ; NOTNULL(elt); elt = elt->next.row ) {
       cur_row=tocur[elt->row];
       if( in_range(rng,cur_row) )
@@ -1255,7 +1255,7 @@ real64 mtx_sum_sqrs_in_row( mtx_matrix_t mtx, int32 row, const mtx_range_t *rng)
 {
    struct element_t *elt;
    int32 *tocur;
-   register real64 sum;
+   real64 sum;
 
 #if MTX_DEBUG
    if(!mtx_check_matrix(mtx)) return D_ZERO;
@@ -1276,7 +1276,7 @@ real64 mtx_sum_sqrs_in_col( mtx_matrix_t mtx, int32 col, const mtx_range_t *rng)
 {
    struct element_t *elt;
    int32 *tocur;
-   register real64 sum;
+   real64 sum;
 
 #if MTX_DEBUG
    if(!mtx_check_matrix(mtx)) return D_ZERO;
@@ -1297,7 +1297,7 @@ real64 mtx_sum_abs_in_row( mtx_matrix_t mtx, int32 row, const mtx_range_t *rng)
 {
    struct element_t *elt;
    int32 *tocur;
-   register real64 sum;
+   real64 sum;
 
 #if MTX_DEBUG
    if(!mtx_check_matrix(mtx)) return D_ZERO;
@@ -1318,7 +1318,7 @@ real64 mtx_sum_abs_in_col( mtx_matrix_t mtx, int32 col, const mtx_range_t *rng)
 {
    struct element_t *elt;
    int32 *tocur;
-   register real64 sum;
+   real64 sum;
 
 #if MTX_DEBUG
    if(!mtx_check_matrix(mtx)) return D_ZERO;
@@ -1343,7 +1343,7 @@ real64 mtx_row_dot_full_org_vec(mtx_matrix_t mtx,
 {
   struct element_t *elt;
   int32 *tocur;
-  register real64 sum;
+  real64 sum;
 
 #if MTX_DEBUG
   if(!mtx_check_matrix(mtx)) return D_ZERO;
@@ -1361,7 +1361,7 @@ real64 mtx_row_dot_full_org_vec(mtx_matrix_t mtx,
       }
     } else {
       if( rng->high >= rng->low ) {
-        register int32 cur;
+        int32 cur;
         for( ; NOTNULL(elt); elt = elt->next.col ) {
           cur=tocur[elt->col];
           if( in_range(rng,cur) ) {
@@ -1377,7 +1377,7 @@ real64 mtx_row_dot_full_org_vec(mtx_matrix_t mtx,
       }
     } else {
       if( rng->high >= rng->low ) {
-        register int32 cur,org;
+        int32 cur,org;
         for( ; NOTNULL(elt); elt = elt->next.col ) {
           cur=tocur[org=elt->col];
           if( in_range(rng,cur) ) {
@@ -1398,7 +1398,7 @@ real64 mtx_col_dot_full_org_vec(mtx_matrix_t mtx,
 {
   struct element_t *elt;
   int32 *tocur;
-  register real64 sum;
+  real64 sum;
 
 #if MTX_DEBUG
   if(!mtx_check_matrix(mtx)) return D_ZERO;
@@ -1416,7 +1416,7 @@ real64 mtx_col_dot_full_org_vec(mtx_matrix_t mtx,
       }
     } else {
       if( rng->high >= rng->low ) {
-        register int32 cur;
+        int32 cur;
         for( ; NOTNULL(elt); elt = elt->next.row ) {
           cur=tocur[elt->row];
           if( in_range(rng,cur) ) {
@@ -1432,7 +1432,7 @@ real64 mtx_col_dot_full_org_vec(mtx_matrix_t mtx,
       }
     } else {
       if( rng->high >= rng->low ) {
-        register int32 org,cur;
+        int32 org,cur;
         for( ; NOTNULL(elt); elt = elt->next.row ) {
           cur=tocur[org=elt->row];
           if( in_range(rng,cur) ) {
@@ -1453,7 +1453,7 @@ real64 mtx_row_dot_full_cur_vec(mtx_matrix_t mtx,
 {
   struct element_t *elt;
   int32 *tocur;
-  register real64 sum;
+  real64 sum;
 
 #if MTX_DEBUG
   if(!mtx_check_matrix(mtx)) return D_ZERO;
@@ -1468,7 +1468,7 @@ real64 mtx_row_dot_full_cur_vec(mtx_matrix_t mtx,
       }
     } else {
       if( rng->high >= rng->low ) {
-        register int32 cur;
+        int32 cur;
         for( ; NOTNULL(elt); elt = elt->next.col ) {
           cur=tocur[elt->col];
           if( in_range(rng,cur) ) {
@@ -1493,7 +1493,7 @@ real64 mtx_col_dot_full_cur_vec(mtx_matrix_t mtx,
 {
   struct element_t *elt;
   int32 *tocur;
-  register real64 sum;
+  real64 sum;
 
 #if MTX_DEBUG
   if(!mtx_check_matrix(mtx)) return D_ZERO;
@@ -1508,7 +1508,7 @@ real64 mtx_col_dot_full_cur_vec(mtx_matrix_t mtx,
       }
     } else {
       if( rng->high >= rng->low ) {
-        register int32 cur;
+        int32 cur;
         for( ; NOTNULL(elt); elt = elt->next.row ) {
           cur=tocur[elt->row];
           if( in_range(rng,cur) ) {
@@ -1533,7 +1533,7 @@ real64 mtx_row_dot_full_org_custom_vec(mtx_matrix_t mtx,
 {
   struct element_t *elt;
   int32 *tocur;
-  register real64 sum;
+  real64 sum;
 
 #if MTX_DEBUG
   if(!mtx_check_matrix(mtx)) return D_ZERO;
@@ -1551,7 +1551,7 @@ real64 mtx_row_dot_full_org_custom_vec(mtx_matrix_t mtx,
       }
     } else {
       if( rng->high >= rng->low ) {
-        register int32 cur;
+        int32 cur;
         for( ; NOTNULL(elt); elt = elt->next.col ) {
           cur=tocur[elt->col];
           if( in_range(rng,cur) ) {
@@ -1569,7 +1569,7 @@ real64 mtx_row_dot_full_org_custom_vec(mtx_matrix_t mtx,
       }
     } else {
       if( rng->high >= rng->low ) {
-        register int32 cur;
+        int32 cur;
         for( ; NOTNULL(elt); elt = elt->next.col ) {
           cur=tocur[elt->col];
           if( in_range(rng,cur) ) {
@@ -1591,7 +1591,7 @@ real64 mtx_col_dot_full_org_custom_vec(mtx_matrix_t mtx,
 {
   struct element_t *elt;
   int32 *tocur;
-  register real64 sum;
+  real64 sum;
 
 #if MTX_DEBUG
   if(!mtx_check_matrix(mtx)) return D_ZERO;
@@ -1609,7 +1609,7 @@ real64 mtx_col_dot_full_org_custom_vec(mtx_matrix_t mtx,
       }
     } else {
       if( rng->high >= rng->low ) {
-        register int32 cur;
+        int32 cur;
         for( ; NOTNULL(elt); elt = elt->next.row ) {
           cur=tocur[elt->row];
           if( in_range(rng,cur) ) {
@@ -1627,7 +1627,7 @@ real64 mtx_col_dot_full_org_custom_vec(mtx_matrix_t mtx,
       }
     } else {
       if( rng->high >= rng->low ) {
-        register int32 cur;
+        int32 cur;
         for( ; NOTNULL(elt); elt = elt->next.row ) {
           cur=tocur[elt->row];
           if( in_range(rng,cur) ) {
@@ -1663,7 +1663,7 @@ void mtx_org_vec_add_row(mtx_matrix_t mtx, real64 *vec, int32 row,
       return;
     }
     if( rng->high >= rng->low ) {
-      register int32 cur_col,lo,hi;
+      int32 cur_col,lo,hi;
 
       lo=rng->low; hi=rng->high;
       for( ; NOTNULL(elt); elt = elt->next.col ) {
@@ -1682,7 +1682,7 @@ void mtx_org_vec_add_row(mtx_matrix_t mtx, real64 *vec, int32 row,
     }
     if( rng->high >= rng->low ) {
       int32 *tocur;
-      register int32 cur_col, org_col,lo,hi;
+      int32 cur_col, org_col,lo,hi;
       lo=rng->low; hi=rng->high;
       tocur = mtx->perm.col.org_to_cur;
       for( ; NOTNULL(elt); elt = elt->next.col ) {
@@ -1717,7 +1717,7 @@ void mtx_org_vec_add_col(mtx_matrix_t mtx, real64 *vec, int32 col,
       return;
     }
     if( rng->high >= rng->low ) {
-      register int32 cur_row,lo,hi;
+      int32 cur_row,lo,hi;
       lo=rng->low; hi=rng->high;
       for( ; NOTNULL(elt); elt = elt->next.row ) {
         cur_row = org2row[elt->row];
@@ -1734,7 +1734,7 @@ void mtx_org_vec_add_col(mtx_matrix_t mtx, real64 *vec, int32 col,
       return;
     }
     if( rng->high >= rng->low ) {
-      register int32 cur_row, org_row,lo,hi;
+      int32 cur_row, org_row,lo,hi;
       int32 *tocur;
 
       lo=rng->low; hi=rng->high;
@@ -1767,7 +1767,7 @@ void mtx_cur_vec_add_row(mtx_matrix_t mtx, real64 *vec, int32 row,
       return;
     }
     if( rng->high >= rng->low ) {
-      register int32 cur_col,lo,hi;
+      int32 cur_col,lo,hi;
       lo= rng->low; hi=rng->high;
       for( ; NOTNULL(elt); elt = elt->next.col ) {
         cur_col=tocur[elt->col];
@@ -1799,7 +1799,7 @@ void mtx_cur_vec_add_col(mtx_matrix_t mtx, real64 *vec, int32 col,
       return;
     }
     if( rng->high >= rng->low ) {
-      register int32 cur_row,lo,hi;
+      int32 cur_row,lo,hi;
       lo= rng->low; hi=rng->high;
       for( ; NOTNULL(elt); elt = elt->next.row ) {
         cur_row=tocur[elt->row];

--- a/ascend/linear/mtx_use_only.c
+++ b/ascend/linear/mtx_use_only.c
@@ -43,7 +43,7 @@ FILE *g_mtxerr;
 struct element_t *mtx_find_element(mtx_matrix_t mtx, int32 org_row,
                                    int32 org_col)
 {
-   register struct element_t *elt;
+   struct element_t *elt;
 
 /* old way.
    for( elt = mtx->hdr.row[org_row] ; NOTNULL(elt) ; elt = elt->next.col )
@@ -63,7 +63,7 @@ struct element_t *mtx_create_element(mtx_matrix_t mtx,
  ***  initially zero.
  **/
 {
-  register struct element_t *elt;
+  struct element_t *elt;
 
 #if MTX_DEBUG
   if( NOTNULL(mtx_find_element(mtx,org_row,org_col)) ) {
@@ -88,7 +88,7 @@ struct element_t *mtx_create_element_value(mtx_matrix_t mtx,
                                            int32 org_col,
                                            real64 val)
 {
-  register struct element_t *elt;
+  struct element_t *elt;
 
 #if MTX_DEBUG
   if( NOTNULL(mtx_find_element(mtx,org_row,org_col)) ) {
@@ -109,7 +109,7 @@ struct element_t *mtx_create_element_value(mtx_matrix_t mtx,
 }
 
 /* new version */
-struct element_t *mtx_next_col(register struct element_t *elt,
+struct element_t *mtx_next_col(struct element_t *elt,
                                mtx_range_t *rng, int32 *tocur)
 {
    if( NOTNULL(elt) ) {
@@ -128,7 +128,7 @@ struct element_t *mtx_next_col(register struct element_t *elt,
 }
 
 /* original version */
-struct element_t *mtx_next_row(register struct element_t *elt,
+struct element_t *mtx_next_row(struct element_t *elt,
                                mtx_range_t *rng, int32 *tocur)
 {
    if( NOTNULL(elt) ) elt = elt->next.row;

--- a/ascend/linear/mtx_vector.c
+++ b/ascend/linear/mtx_vector.c
@@ -273,7 +273,7 @@ void vec_write(FILE *fp, struct vec_vector *vec){
 /* Dot product for loop unrolled vector norms */
 real64 vec_dot(int32 len, const real64 *p1, const real64 *p2)
 {
-  register double sum,lsum;
+  double sum,lsum;
   int m,n;
 
 /* 

--- a/ascend/linear/plainqr.c
+++ b/ascend/linear/plainqr.c
@@ -372,7 +372,7 @@ static boolean cpqr_get_householder(linsolqr_system_t sys,
    An untrapped underflow must have occurred, because we had a nonzero above.
   */
   if (t != D_ZERO) {
-    register double apiv;
+    double apiv;
     /* scale the hhcol by stewarts 1/pi sqrt, essentially */
     for (i = 0; i < sp->len; i++) {
       sp->data[i] *= t;
@@ -622,7 +622,7 @@ static void cpqr_forward_eliminate(linsolqr_system_t sys,
     /* arr is indexed by original column number */
     int32 dotlim,col;
     const real64 *diag;
-    register int32 org_col;
+    int32 org_col;
 
     mtx = sys->factors;
     diag = sys->qrdata->alpha;

--- a/ascend/linear/ranki.c
+++ b/ascend/linear/ranki.c
@@ -413,7 +413,7 @@ void forward_substitute(linsolqr_system_t sys,
    dotlim=dot_rng.low+sys->rank;
    if (transpose) {     /* arr is indexed by original column number */
      for( nz.col=dot_rng.low; nz.col < dotlim; ++(nz.col) ) {
-       register int32 org_col;
+       int32 org_col;
 
        dot_rng.high = nz.col - 1;
        org_col = mtx_col_to_org(mtx,nz.col);
@@ -427,7 +427,7 @@ void forward_substitute(linsolqr_system_t sys,
 
    } else {             /* arr is indexed by original row number */
      for( nz.row=dot_rng.low; nz.row < dotlim; ++(nz.row) ) {
-       register int32 org_row;
+       int32 org_row;
 
        dot_rng.high = nz.row - 1;
        org_row = mtx_row_to_org(mtx,nz.row);
@@ -483,7 +483,7 @@ void backward_substitute(linsolqr_system_t sys,
    pivlist=sys->ludata->pivlist;
    if (transpose) {     /* arr is indexed by original column number */
      for( nz.col = dot_rng.high ; nz.col >= dotlim ; --(nz.col) ) {
-       register int32 org_col;
+       int32 org_col;
 
        dot_rng.low = nz.col + 1;
 
@@ -502,7 +502,7 @@ void backward_substitute(linsolqr_system_t sys,
    } else {             /* arr is indexed by original row number */
      /* we are working from the bottom up */
      for( nz.row = dot_rng.high ; nz.row >= dotlim ; --(nz.row) ) {
-       register int32 org_row;
+       int32 org_row;
 
        dot_rng.low = nz.row + 1;
        org_row = mtx_row_to_org(mtx,nz.row);

--- a/ascend/linear/ranki2.c
+++ b/ascend/linear/ranki2.c
@@ -398,7 +398,7 @@ void forward_substitute2(linsolqr_system_t sys,
   if (transpose) { /* arr is indexed by original column number */
     mtx=sys->inverse;
     for( nz.col=sys->rng.low; nz.col < dotlim; ++(nz.col) ) {
-      register int32 org_col;
+      int32 org_col;
 
       org_col = mtx_col_to_org(mtx,nz.col);
       if (arr[org_col]!=D_ZERO) nonzero_found=TRUE;
@@ -411,7 +411,7 @@ void forward_substitute2(linsolqr_system_t sys,
   } else { /* arr is indexed by original row number */
     mtx=sys->factors;
     for( nz.row=sys->rng.low; nz.row < dotlim; ++(nz.row) ) {
-      register int32 org_row;
+      int32 org_row;
 
       org_row = mtx_row_to_org(mtx,nz.row);
       if (arr[org_row]!=D_ZERO) nonzero_found=TRUE;
@@ -450,7 +450,7 @@ void backward_substitute2(linsolqr_system_t sys,
   if (transpose) { /* arr is indexed by original column number */
     mtx = sys->factors;
     for( nz.col = sys->rng.low+sys->rank-1; nz.col >= dotlim ; --(nz.col) ) {
-      register int32 org_col;
+      int32 org_col;
 
       org_col = mtx_col_to_org(mtx,nz.col);
       if (arr[org_col] != D_ZERO) nonzero_found=TRUE;
@@ -463,7 +463,7 @@ void backward_substitute2(linsolqr_system_t sys,
     /* we are working from the bottom up */
     mtx = sys->inverse;
     for( nz.row = sys->rng.low+sys->rank-1; nz.row >= dotlim ; --(nz.row) ) {
-      register int32 org_row;
+      int32 org_row;
 
       org_row = mtx_row_to_org(mtx,nz.row);
       if (arr[org_row]!=D_ZERO) nonzero_found=TRUE;

--- a/ascend/system/calc.c
+++ b/ascend/system/calc.c
@@ -197,7 +197,7 @@ real64 calc_rec(real64 x)
 #define CUBRTHUGE      5.6438030941223618e102
 /* largest cubeable number in an 8 byte ieee double */
 #endif
-real64 calc_cube(register real64 x)
+real64 calc_cube(real64 x)
 {
    if( fabs(x) > CUBRTHUGE || fabs(x) < INV_CUBRTHUGE ) {
       real64 bogus;
@@ -266,7 +266,7 @@ real64 calc_erf_inv(real64 x)
 
 real64 calc_lnm_inv(real64 x)
 {
-   register double eps=FuncGetLnmEpsilon();
+   double eps=FuncGetLnmEpsilon();
    if( x > (MAXDOUBLE > 1.0e308 ? 709.196209 : log(MAXDOUBLE)) ) {
       real64 bogus = BIGNUM;
       if( calc_print_errors ) {
@@ -426,7 +426,7 @@ real64 calc_sqrt_D0(real64 x)
    return(sqrt(x));
 }
 
-real64 calc_tan_D1(register real64 x)
+real64 calc_tan_D1(real64 x)
 {
    x=cos(x);
    return( calc_rec(calc_sqr_D0(x)) );
@@ -497,7 +497,7 @@ real64 calc_tan_D2(real64 x)
 
 real64 calc_arcsin_D2(real64 x)
 {
-   register double t;
+   double t;
    t = calc_rec(1.0 - calc_sqr_D0(x));
    return( calc_mul_D0( calc_mul_D0(x,t) , calc_mul_D0(t,t) ) );
 }

--- a/ascend/utilities/bit.c
+++ b/ascend/utilities/bit.c
@@ -39,9 +39,9 @@ typedef unsigned char byte;
 
 
 struct BitList *CreateBList(unsigned long int len){
-  register struct BitList *result;
-  register unsigned long num_bytes;
-  register char *ptr;
+  struct BitList *result;
+  unsigned long num_bytes;
+  char *ptr;
   num_bytes = len >> 3;		/* divide by 8 */
   if(len & 0x07)num_bytes++;
   //CONSOLE_DEBUG("num_bytes = %lu",num_bytes);
@@ -57,8 +57,8 @@ struct BitList *CreateBList(unsigned long int len){
 
 
 struct BitList *CreateFBList(unsigned long int len){
-  register struct BitList *result;
-  register unsigned long c;
+  struct BitList *result;
+  unsigned long c;
   result = CreateBList(len);
   AssertContainedMemory(result,sizeof(struct BitList));
   /* the following should be memset, plus cleanup of unused bits */
@@ -68,8 +68,8 @@ struct BitList *CreateFBList(unsigned long int len){
 
 
 struct BitList *ExpandBList(struct BitList *bl, unsigned long int len){
-  register unsigned orig_len,old_bytes,new_bytes;
-  register struct BitList *result;
+  unsigned orig_len,old_bytes,new_bytes;
+  struct BitList *result;
   AssertContainedMemory(bl,sizeof(struct BitList));
   orig_len = BLength(bl);
   assert(len>=orig_len);
@@ -92,7 +92,7 @@ struct BitList *ExpandBList(struct BitList *bl, unsigned long int len){
 
 
 struct BitList *ExpandFBList(struct BitList *bl, unsigned long int len){
-  register unsigned long oldlen;
+  unsigned long oldlen;
   AssertContainedMemory(bl,sizeof(struct BitList));
   oldlen = BLength(bl);
   bl = ExpandBList(bl,len);
@@ -110,8 +110,8 @@ void DestroyBList(struct BitList *bl){
 
 
 struct BitList *CopyBList(CONST struct BitList *bl){
-  register struct BitList *copy;
-  register unsigned long num_bytes;
+  struct BitList *copy;
+  unsigned long num_bytes;
   num_bytes = BLENGTH(bl) >> 3;	/* divide by 8 */
   if (BLENGTH(bl) & 0x07) num_bytes++;
   AssertAllocatedMemory(bl,sizeof(struct BitList)+num_bytes);
@@ -124,7 +124,7 @@ struct BitList *CopyBList(CONST struct BitList *bl){
 
 
 void OverwriteBList(CONST struct BitList *bl, struct BitList *target){
-  register unsigned long num_bytes;
+  unsigned long num_bytes;
 
   assert(bl!=target);
   assert(bl!=NULL);
@@ -144,7 +144,7 @@ void OverwriteBList(CONST struct BitList *bl, struct BitList *target){
 
 
 unsigned long BitListBytes(CONST struct BitList *bl){
-  register unsigned long num_bytes;
+  unsigned long num_bytes;
   if (bl==NULL) return 0;
   num_bytes = BLENGTH(bl) >> 3; /* divide by 8 */
   if (BLENGTH(bl) & 0x07) num_bytes++;
@@ -153,8 +153,8 @@ unsigned long BitListBytes(CONST struct BitList *bl){
 
 
 void SetBit(struct BitList *bl, unsigned long int pos){
-  register byte *ptr;
-  register unsigned bit;
+  byte *ptr;
+  unsigned bit;
   asc_assert(pos < bl->length);
   AssertContainedMemory(bl,sizeof(struct BitList));
   ptr = (byte *)((asc_intptr_t)bl+sizeof(struct BitList)+(pos >> 3));
@@ -165,8 +165,8 @@ void SetBit(struct BitList *bl, unsigned long int pos){
 
 
 void ClearBit(struct BitList *bl, unsigned long int pos){
-  register byte *ptr;
-  register unsigned bit;
+  byte *ptr;
+  unsigned bit;
   AssertContainedMemory(bl,sizeof(struct BitList));
   asc_assert(pos < bl->length);
   ptr = (byte *)((asc_intptr_t)bl+sizeof(struct BitList)+(pos >> 3));
@@ -177,8 +177,8 @@ void ClearBit(struct BitList *bl, unsigned long int pos){
 
 
 void CondSetBit(struct BitList *bl, unsigned long int pos, int cond){
-  register byte *ptr;
-  register unsigned bit;
+  byte *ptr;
+  unsigned bit;
   AssertContainedMemory(bl,sizeof(struct BitList));
   asc_assert(pos < bl->length);
   ptr = (byte *)((asc_intptr_t)bl+sizeof(struct BitList)+(pos >> 3));
@@ -192,8 +192,8 @@ void CondSetBit(struct BitList *bl, unsigned long int pos, int cond){
 
 
 int ReadBit(CONST struct BitList *bl, unsigned long int pos){
-  register byte *ptr;
-  register unsigned bit;
+  byte *ptr;
+  unsigned bit;
   AssertContainedMemory(bl,sizeof(struct BitList));
   asc_assert(pos < bl->length);
   ptr = (byte *)((asc_intptr_t)bl+sizeof(struct BitList)+(pos >> 3));
@@ -206,9 +206,9 @@ int ReadBit(CONST struct BitList *bl, unsigned long int pos){
 
 
 void IntersectBLists(struct BitList *bl1, CONST struct BitList *bl2){
-  register byte *ptr1;
-  register CONST byte *ptr2;
-  register unsigned long num_bytes;
+  byte *ptr1;
+  CONST byte *ptr2;
+  unsigned long num_bytes;
   AssertContainedMemory(bl1,sizeof(struct BitList));
   AssertContainedMemory(bl2,sizeof(struct BitList));
   if (BLENGTH(bl1)!=BLENGTH(bl2)) {
@@ -230,9 +230,9 @@ void IntersectBLists(struct BitList *bl1, CONST struct BitList *bl2){
 
 
 void UnionBLists(struct BitList *bl1, CONST struct BitList *bl2){
-  register byte *ptr1;
-  register CONST byte *ptr2;
-  register unsigned long num_bytes;
+  byte *ptr1;
+  CONST byte *ptr2;
+  unsigned long num_bytes;
   AssertContainedMemory(bl1,sizeof(struct BitList));
   AssertContainedMemory(bl2,sizeof(struct BitList));
   if (BLENGTH(bl1)!=BLENGTH(bl2)) {
@@ -260,8 +260,8 @@ unsigned long BLengthF(CONST struct BitList *bl){
 
 
 int BitListEmpty(CONST struct BitList *bl){
-  register unsigned long num_bytes;
-  register unsigned char *ptr;
+  unsigned long num_bytes;
+  unsigned char *ptr;
   AssertContainedMemory(bl,sizeof(struct BitList));
   num_bytes = bl->length >> 3;
   if (bl->length & 0x07) num_bytes++;
@@ -300,8 +300,8 @@ static void printbits(const struct BitList *bl){
 #endif
 
 unsigned long FirstNonZeroBit(CONST struct BitList *bl){
-  register unsigned long num_bytes,c,b;
-  register unsigned char *ptr,ch;
+  unsigned long num_bytes,c,b;
+  unsigned char *ptr,ch;
 
   //printbits(bl);
 

--- a/ascend/utilities/readln.c
+++ b/ascend/utilities/readln.c
@@ -37,7 +37,7 @@
  **/
 static int killnl(char *s, int *nl)
 {
-   register char *end;
+   char *end;
 
    end = s + strlen(s);
    if( (*nl = (end != s && end[-1] == '\n')) ) {


### PR DESCRIPTION
in any modern processor, registers are not in short supply and we don't need register hints any more.