### PR TITLE
fix invalid memory use error in tests ascEnvVar slv dstring

### DIFF
--- a/ascend/general/test/test_dstring.c
+++ b/ascend/general/test/test_dstring.c
@@ -43,14 +43,14 @@ static void test_dstring(void)
   prior_meminuse = ascmeminuse();
 
   /* set up test strings */
-  memset(&str_statsize_m1, '?', ASC_DSTRING_STATIC_SIZE-3);
-  str_statsize_m1[ASC_DSTRING_STATIC_SIZE-2] = '\0';
+  memset(str_statsize_m1, '?', ASC_DSTRING_STATIC_SIZE-2); // write n-2 bytes into a string size n-1
+  str_statsize_m1[ASC_DSTRING_STATIC_SIZE-2] = '\0'; // write nul at byte n-1-1
 
-  memset(&str_statsize, '=', ASC_DSTRING_STATIC_SIZE-2);
-  str_statsize[ASC_DSTRING_STATIC_SIZE-1] = '\0';
+  memset(str_statsize, '=', ASC_DSTRING_STATIC_SIZE-1); // n-1 bytes into size n
+  str_statsize[ASC_DSTRING_STATIC_SIZE-1] = '\0'; // write nul at byte n-1
 
-  memset(&str_statsize_p1, '|', ASC_DSTRING_STATIC_SIZE-1);
-  str_statsize_p1[ASC_DSTRING_STATIC_SIZE] = '\0';
+  memset(str_statsize_p1, '|', ASC_DSTRING_STATIC_SIZE); // n bytes into size n+1
+  str_statsize_p1[ASC_DSTRING_STATIC_SIZE] = '\0'; // write nul at byte n-1+1
 
   strcpy(str_statcat1, str_statsize_m1);
   strcat(str_statcat1, str_statsize);

--- a/ascend/solver/test/test_slv_common.c
+++ b/ascend/solver/test/test_slv_common.c
@@ -124,7 +124,7 @@ static void test_slv_common(void)
   mtx_coord_t coord;
   mtx_region_t region;
   real64 rarray[100];
-  real64 rarray2[100];
+  real64 rarray2[100] = { 0 };
   int i;
   FILE *file_normal;
   int32 hi[11];

--- a/ascend/utilities/test/test_ascEnvVar.c
+++ b/ascend/utilities/test/test_ascEnvVar.c
@@ -49,14 +49,14 @@ int compare_strings(CONST VOIDPTR p1, CONST VOIDPTR p2)
 
 static void test_ascEnvVar(void)
 {
-  char str_path[STR_LEN];
-  char str_path_ss1[STR_LEN];
-  char str_path_ss2[STR_LEN];
-  char str_path_ss3[STR_LEN];
+  char str_path[STR_LEN] = { 0 };
+  char str_path_ss1[STR_LEN] = { 0 };
+  char str_path_ss2[STR_LEN] = { 0 };
+  char str_path_ss3[STR_LEN] = { 0 };
 
-  char str_pathbig[MAX_ENV_VAR_LENGTH*3+1];
-  char str_pathbig_ss1[MAX_ENV_VAR_LENGTH*3+1];
-  char str_pathbig_ss2[MAX_ENV_VAR_LENGTH*3+1];
+  char str_pathbig[MAX_ENV_VAR_LENGTH*3+1] = { 0 };
+  char str_pathbig_ss1[MAX_ENV_VAR_LENGTH*3+1] = { 0 };
+  char str_pathbig_ss2[MAX_ENV_VAR_LENGTH*3+1] = { 0 };
 
   int elem_count;
   const char **paths;
@@ -152,18 +152,16 @@ static void test_ascEnvVar(void)
 
   CU_TEST(0 == Asc_SetPathList("envar2e3", str_path));  /* 2 elements, both empty */
   paths = Asc_GetPathList("envar2e3", &elem_count);
-  CU_TEST_FATAL(NULL != paths);
-  CU_TEST(paths[0][0] == '\0');
   CU_TEST(0 == elem_count);
+  CU_TEST_FATAL(NULL != paths);
   if (NULL != paths) ascfree(paths);
 
   SNPRINTF(str_path, STR_LEN-1, "  %c  ", PATHDIV);
 
   CU_TEST(0 == Asc_SetPathList("envar2e4", str_path));  /* 2 elements, both empty with ws */
   paths = Asc_GetPathList("envar2e4", &elem_count);
-  CU_TEST_FATAL(NULL != paths);
-  CU_TEST(paths[0][0] == '\0');
   CU_TEST(0 == elem_count);
+  CU_TEST_FATAL(NULL != paths);
   if (NULL != paths) ascfree(paths);
 
   SNPRINTF(str_path, STR_LEN-1, "%s%c%s%c%s", "< spaces >",
@@ -215,9 +213,8 @@ static void test_ascEnvVar(void)
 
   CU_TEST(0 == Asc_SetPathList("envar3e3", str_path));  /* 3 elements - all empty */
   paths = Asc_GetPathList("envar3e3", &elem_count);
-  CU_TEST_FATAL(NULL != paths);
-  CU_TEST(paths[0][0] == '\0');
   CU_TEST(0 == elem_count);
+  CU_TEST_FATAL(NULL != paths);
   if (NULL != paths) ascfree(paths);
 
   memset(str_pathbig, '.', MAX_ENV_VAR_LENGTH-2);
@@ -377,7 +374,6 @@ static void test_ascEnvVar(void)
   CU_TEST(0 == Asc_PutEnv(str_path));                   /* 2 elements, both empty */
   paths = Asc_GetPathList("envar2e3", &elem_count);
   CU_TEST_FATAL(NULL != paths);
-  CU_TEST(paths[0][0] == '\0');
   CU_TEST(0 == elem_count);
   if (NULL != paths) ascfree(paths);
 
@@ -385,9 +381,8 @@ static void test_ascEnvVar(void)
 
   CU_TEST(0 == Asc_PutEnv(str_path));                   /* 2 elements, both empty with ws */
   paths = Asc_GetPathList("envar2e4", &elem_count);
-  CU_TEST_FATAL(NULL != paths);
-  CU_TEST(paths[0][0] == '\0');
   CU_TEST(0 == elem_count);
+  CU_TEST_FATAL(NULL != paths);
   if (NULL != paths) ascfree(paths);
 
   SNPRINTF(str_path, STR_LEN-1, "envar3=%s%c%s%c%s", "< spaces >",
@@ -440,7 +435,6 @@ static void test_ascEnvVar(void)
   CU_TEST(0 == Asc_PutEnv(str_path));                   /* 3 elements - all empty */
   paths = Asc_GetPathList("envar3e3", &elem_count);
   CU_TEST_FATAL(NULL != paths);
-  CU_TEST(paths[0][0] == '\0');
   CU_TEST(0 == elem_count);
   if (NULL != paths) ascfree(paths);
 


### PR DESCRIPTION
After rereading the EnvVar header, some of the assertions in the test are invalid and this removes them.
Valgrind revealed the slv test was using uninitialized arrays in dot operations, which invalidates the dependent assertions in the tests. Fixed the missing inits.
Second commit fixes incomplete string inits in test_dstring.