### PR TITLE
makemps solver re-enabled; relman_is_linear fixed; calc_uses relman_d…

### DIFF
--- a/.github/workflows/msys2.yml
+++ b/.github/workflows/msys2.yml
@@ -42,6 +42,7 @@ jobs:
           mingw-w64-${{matrix.env}}-gtk2
           mingw-w64-${{matrix.env}}-binutils
           mingw-w64-${{matrix.env}}-pkg-config
+          mingw-w64-${{matrix.env}}-highs
           mingw-w64-${{matrix.env}}-python
           mingw-w64-${{matrix.env}}-python-pip
           mingw-w64-${{matrix.env}}-python-wheel

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -10,6 +10,8 @@ on:
 jobs:
   build:
     runs-on: ${{ matrix.os }}
+    env:
+      HIGHS_VERSION: v1.13.1
     strategy:
       fail-fast: false
       matrix:
@@ -25,7 +27,7 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install automake autoconf libtool build-essential gfortran flex bison scons swig doxygen tcl8.6 tcl8.6-dev tk8.6 tk8.6-dev tk-table graphviz libgraphviz-dev python3-dev libgtk-3-dev python3-gi python3-numpy liblapack-dev libblas-dev libsundials-dev coinor-libipopt-dev  libmumps-seq-dev libpcre3-dev python3-packaging subversion
+        sudo apt-get install automake autoconf libtool build-essential gfortran flex bison scons swig doxygen tcl8.6 tcl8.6-dev tk8.6 tk8.6-dev tk-table graphviz libgraphviz-dev python3-dev libgtk-3-dev python3-gi python3-numpy liblapack-dev libblas-dev libsundials-dev coinor-libipopt-dev  libmumps-seq-dev libpcre3-dev python3-packaging subversion cmake
 
     - name: Build and install CUnit
       run: |
@@ -36,8 +38,36 @@ jobs:
         make -j8
         make install
 
+    - name: Cache HiGHS install
+      id: highs_cache
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.local/bin/highs
+          ~/.local/include/highs
+          ~/.local/include/interfaces/highs_c_api.h
+          ~/.local/lib/libhighs*
+          ~/.local/lib/pkgconfig/highs.pc
+          ~/.local/lib64/libhighs*
+          ~/.local/lib64/pkgconfig/highs.pc
+        key: ${{ runner.os }}-${{ matrix.os }}-highs-${{ env.HIGHS_VERSION }}
+
+    - name: Build and install HiGHS
+      if: steps.highs_cache.outputs.cache-hit != 'true'
+      run: |
+        git clone --branch "$HIGHS_VERSION" --depth 1 https://github.com/ERGO-Code/HiGHS.git highs
+        cd highs
+        cmake -S . -B build \
+          -DCMAKE_BUILD_TYPE=Release \
+          -DCMAKE_INSTALL_PREFIX=$HOME/.local \
+          -DBUILD_SHARED_LIBS=ON
+        cmake --build build -j
+        cmake --install build
+
     - name: Build ASCEND
       run: |
+        export PATH="$HOME/.local/bin:$PATH"
+        export PKG_CONFIG_PATH="$HOME/.local/lib/pkgconfig:$HOME/.local/lib64/pkgconfig:${PKG_CONFIG_PATH:-}"
         scons GCOV=1 CUNIT_PREFIX=$HOME/.local MALLOC_DEBUG=1 ascend models solvers ascxx pygtk test a4
 
     - name: ASCEND CUnit tests

--- a/SConstruct
+++ b/SConstruct
@@ -347,7 +347,7 @@ vars.Add(ListVariable('WITH_SOLVERS'
 	,["QRSLV","CMSLV","LSODE","IDA","CONOPT","LRSLV","IPOPT","DOPRI5"]
 	,['QRSLV','MPS','SLV','OPTSQP'
 		,'NGSLV','CMSLV','LRSLV','MINOS','CONOPT'
-		,'LSODE','LSOD','OPTSQP',"IDA","TRON","IPOPT","DOPRI5","MAKEMPS","RADAU5"
+		,'LSODE','LSOD','OPTSQP',"IDA","TRON","IPOPT","DOPRI5","MAKEMPS","HIGHS","RADAU5"
 	 ]
 ))
 
@@ -510,6 +510,13 @@ vars.Add('CONOPT_ENVVAR'
 vars.Add(PackageVariable("IPOPT_PREFIX"
 	,"Prefix for your IPOPT install (IPOPT ./configure --prefix)"
 ,pathlib.Path(os.environ['HOME'])/'.local'
+))
+
+#------- HIGHS -------
+
+vars.Add(PackageVariable("HIGHS_PREFIX"
+	,"Prefix for your HiGHS install (if not found via default pkg-config path)"
+	,pathlib.Path(os.environ['HOME'])/'.local'
 ))
 
 #
@@ -977,7 +984,7 @@ for opt in ['tcltk','cunit','extfns','scrollkeeper','dmalloc','graphviz','ufspar
 if not env['WITH_DOC']:
 	env.set_optional('doc_build',reason='documentation was disabled',active=False)
 
-for solv in 'LSODE','IDA','DOPRI5','RADAU5','CONOPT','IPOPT','MAKEMPS':
+for solv in 'LSODE','IDA','DOPRI5','RADAU5','CONOPT','IPOPT','MAKEMPS','HIGHS':
 	env.set_optional(solv,active = solv in env['WITH_SOLVERS'], reason="Not selected (see option WITH_SOLVERS)")
 	
 

--- a/ascend/linear/mtx_basic.c
+++ b/ascend/linear/mtx_basic.c
@@ -437,7 +437,7 @@ mtx_coord_t *mtx_coord(mtx_coord_t *coordp, int32 row, int32 col){
    return(coordp);
 }
 
-mtx_range_t *mtx_range(mtx_range_t *rangep, int32 low, int32 high){
+ASC_DLLSPEC mtx_range_t *mtx_range(mtx_range_t *rangep, int32 low, int32 high){
    rangep->low = low;
    rangep->high = high;
    return(rangep);

--- a/ascend/linear/mtx_basic.h
+++ b/ascend/linear/mtx_basic.h
@@ -83,7 +83,7 @@ ASC_DLLSPEC mtx_coord_t *mtx_coord(mtx_coord_t *coordp, int32 row, int32 col);
 	    value = mtx_value(matrix,mtx_coord(&coord,row,col));
 	  }                                                </pre>
 */
-extern mtx_range_t *mtx_range(mtx_range_t *rangep, int32 low, int32 high);
+ASC_DLLSPEC mtx_range_t *mtx_range(mtx_range_t *rangep, int32 low, int32 high);
 /**<
 	Places the values of low and high into rangep and returns
 	the rangep pointer again.

--- a/ascend/linear/mtx_perms.c
+++ b/ascend/linear/mtx_perms.c
@@ -313,7 +313,7 @@ static void swap( struct permutation_t *perm, int32 cur1,int32 cur2)
    perm->parity = !(perm->parity);
 }
 
-void mtx_swap_rows( mtx_matrix_t mtx, int32 cur1,int32 cur2)
+ASC_DLLSPEC void mtx_swap_rows( mtx_matrix_t mtx, int32 cur1,int32 cur2)
 {
 #if MTX_DEBUG
   if(!mtx_check_matrix(mtx)) return;

--- a/ascend/linear/mtx_perms.h
+++ b/ascend/linear/mtx_perms.h
@@ -135,7 +135,7 @@ extern size_t mtx_block_perm_size(mtx_block_perm_t bperm);
   MTX PERMUTATION AND PERMUTATION INFO ROUTINES
 */
 
-extern void mtx_swap_rows(mtx_matrix_t mtx, int32 row1, int32 row2);
+ASC_DLLSPEC void mtx_swap_rows(mtx_matrix_t mtx, int32 row1, int32 row2);
 /**<
  ***  Swaps two rows of the matrix.  The association between the
  ***  "original row number" and the row contents is not

--- a/ascend/linear/mtx_query.c
+++ b/ascend/linear/mtx_query.c
@@ -59,7 +59,7 @@ real64 mtx_next_in_row( mtx_matrix_t mtx, mtx_coord_t *coord, mtx_range_t *rng)
    return( ISNULL(elt) ? D_ZERO : elt->value );
 }
 
-real64 mtx_next_in_col( mtx_matrix_t mtx, mtx_coord_t *coord, mtx_range_t *rng)
+ASC_DLLSPEC real64 mtx_next_in_col( mtx_matrix_t mtx, mtx_coord_t *coord, mtx_range_t *rng)
 {
    static struct element_t *elt = NULL;
    struct element_t Rewind;
@@ -575,7 +575,7 @@ real64 mtx_get_pivot_row( mtx_matrix_t mtx, mtx_coord_t *coord,
   return(rmax);
 }
 
-int32 mtx_nonzeros_in_row( mtx_matrix_t mtx, int32 row, mtx_range_t *rng)
+ASC_DLLSPEC int32 mtx_nonzeros_in_row( mtx_matrix_t mtx, int32 row, mtx_range_t *rng)
 {
    struct element_t *elt;
    int32 *tocur;

--- a/ascend/linear/mtx_query.h
+++ b/ascend/linear/mtx_query.h
@@ -36,7 +36,7 @@ ASC_DLLSPEC real64 mtx_next_in_row(mtx_matrix_t matrix,
                               mtx_coord_t *coord,
                               mtx_range_t *colrng);
 /**< See mtx_next_in_col(), switching row & column references. */
-extern real64 mtx_next_in_col(mtx_matrix_t matrix,
+ASC_DLLSPEC real64 mtx_next_in_col(mtx_matrix_t matrix,
                               mtx_coord_t *coord,
                               mtx_range_t *rowrng);
 /**<
@@ -178,7 +178,7 @@ extern real64 mtx_get_pivot_row(mtx_matrix_t matrix,
  -$-  Returns -1.0 from a bad matrix.
  **/
 
-extern int32 mtx_nonzeros_in_row(mtx_matrix_t matrix,
+ASC_DLLSPEC int32 mtx_nonzeros_in_row(mtx_matrix_t matrix,
                                  int32 row,
                                  mtx_range_t *colrng);
 /**<

--- a/ascend/solver/solver.c
+++ b/ascend/solver/solver.c
@@ -40,7 +40,7 @@
 # include <windows.h>
 #endif
 
-#define SOLVER_DEBUG
+//#define SOLVER_DEBUG
 #ifdef SOLVER_DEBUG
 # define MSG CONSOLE_DEBUG
 # define ERRMSG CONSOLE_DEBUG

--- a/ascend/solver/test/test_conopt.c
+++ b/ascend/solver/test/test_conopt.c
@@ -155,6 +155,8 @@ static void test_conopt(const char *filenamestem){
 	T(test12) \
 	T(test13) \
 	T(test14) \
+	T(lp1) \
+	T(lp_structured) \
 	T(conopttest)
 
 /* define the tests: each test loads the model, solves with CONOPT, then runs the

--- a/ascend/solver/test/test_highs.c
+++ b/ascend/solver/test/test_highs.c
@@ -1,0 +1,164 @@
+#include <string.h>
+#include <stdlib.h>
+#include <math.h>
+
+#include <ascend/general/ascMalloc.h>
+#include <ascend/utilities/ascEnvVar.h>
+
+#include <ascend/compiler/ascCompiler.h>
+#include <ascend/compiler/module.h>
+#include <ascend/compiler/parser.h>
+#include <ascend/compiler/library.h>
+#include <ascend/compiler/symtab.h>
+#include <ascend/compiler/simlist.h>
+#include <ascend/compiler/instquery.h>
+#include <ascend/compiler/initialize.h>
+#include <ascend/compiler/name.h>
+#include <ascend/compiler/packages.h>
+
+#include <ascend/system/system.h>
+#include <ascend/system/slv_client.h>
+#include <ascend/system/slv_param.h>
+#include <ascend/system/var.h>
+#include <ascend/solver/solver.h>
+
+#include <test/common.h>
+
+struct var_expect{
+	const char *name_substr;
+	double expected;
+	double tol;
+};
+
+static int find_param_index(const slv_parameters_t *pp, const char *name){
+	int i;
+	for(i = 0; i < pp->num_parms; ++i){
+		if(pp->parms[i].name != NULL && 0 == strcmp(pp->parms[i].name,name)){
+			return i;
+		}
+	}
+	return -1;
+}
+
+static int find_solver_var_value(slv_system_t sys, const char *name_substr, double *value){
+	struct var_variable **vars = slv_get_solvers_var_list(sys);
+	if(vars == NULL)return 0;
+	for(; *vars != NULL; ++vars){
+		char *name = var_make_name(sys,*vars);
+		int match = (name != NULL && strstr(name,name_substr) != NULL);
+		if(match){
+			*value = var_value(*vars);
+			ascfree(name);
+			return 1;
+		}
+		if(name)ascfree(name);
+	}
+	return 0;
+}
+
+static void run_highs_model(
+	const char *module_path,
+	const char *model_name,
+	const struct var_expect *vars,
+	int nvars
+){
+	int solver_index = -1;
+	struct Instance *siminst = NULL;
+	slv_system_t sys = NULL;
+	slv_status_t status;
+	int i;
+
+	Asc_CompilerInit(1);
+	CU_TEST(0 == Asc_PutEnv(ASC_ENV_LIBRARY "=models"));
+	CU_TEST(0 == Asc_PutEnv(ASC_ENV_SOLVERS "=solvers/highs"));
+
+	if(0 != package_load("highs",NULL)){
+		CONSOLE_DEBUG("Skipping HiGHS test: solver package not available");
+		goto cleanup;
+	}
+
+	solver_index = slv_lookup_client("HiGHS");
+	if(solver_index == -1){
+		CONSOLE_DEBUG("Skipping HiGHS test: solver not registered");
+		goto cleanup;
+	}
+
+	{
+		int status_open;
+		Asc_OpenModule(module_path,&status_open);
+		CU_ASSERT_FATAL(status_open == 0);
+	}
+	CU_ASSERT(0 == zz_parse());
+	CU_ASSERT_FATAL(FindType(AddSymbol(model_name)) != NULL);
+
+	siminst = SimsCreateInstance(AddSymbol(model_name), AddSymbol("sim1"), e_normal, NULL);
+	CU_ASSERT_FATAL(siminst != NULL);
+
+	{
+		struct Name *name = CreateIdName(AddSymbol("on_load"));
+		enum Proc_enum pe = Initialize(GetSimulationRoot(siminst),name,"sim1", ASCERR, WP_STOPONERR, NULL, NULL);
+		CU_ASSERT(pe == Proc_all_ok);
+	}
+
+	sys = system_build(GetSimulationRoot(siminst));
+	CU_ASSERT_FATAL(sys != NULL);
+	CU_ASSERT_FATAL(slv_select_solver(sys,solver_index) != -1);
+
+	{
+		slv_parameters_t pp;
+		int nonlin_idx;
+		slv_get_parameters(sys,&pp);
+		nonlin_idx = find_param_index(&pp,"nonlin");
+		CU_ASSERT_FATAL(nonlin_idx != -1);
+		SLV_PARAM_BOOL(&pp,nonlin_idx) = FALSE;
+		slv_set_parameters(sys,&pp);
+	}
+
+	(void)slv_presolve(sys);
+	(void)slv_solve(sys);
+	slv_get_status(sys,&status);
+	CU_ASSERT_TRUE(status.converged);
+	CU_ASSERT_FALSE(status.diverged);
+
+	for(i = 0; i < nvars; ++i){
+		double value = 0.0;
+		if(!find_solver_var_value(sys,vars[i].name_substr,&value)){
+			CU_FAIL("Expected variable not found in solver var list");
+			break;
+		}
+		CU_ASSERT_DOUBLE_EQUAL(vars[i].expected,value,vars[i].tol);
+	}
+
+cleanup:
+	if(sys)system_destroy(sys);
+	system_free_reused_mem();
+	solver_destroy_engines();
+	if(siminst)sim_destroy(siminst);
+	Asc_CompilerDestroy();
+}
+
+static void test_highs_lp1(void){
+	static const struct var_expect expected[] = {
+		{"x", 2.0, 1e-7},
+		{"y", 2.0, 1e-7},
+		{"s1", 0.0, 1e-7},
+		{"s2", 0.0, 1e-7}
+	};
+	run_highs_model("models/test/ipopt/lp1.a4c","lp1",expected,4);
+}
+
+static void test_highs_lp_structured(void){
+	static const struct var_expect expected[] = {
+		{"x[1]", 2.0, 1e-7},
+		{"x[2]", 2.0, 1e-7},
+		{"row[1].s", 0.0, 1e-7},
+		{"row[2].s", 0.0, 1e-7}
+	};
+	run_highs_model("models/test/ipopt/lp_structured.a4c","lp_structured",expected,4);
+}
+
+#define TESTS(T) \
+	T(highs_lp1) \
+	T(highs_lp_structured)
+
+REGISTER_TESTS_SIMPLE(solver_highs, TESTS)

--- a/ascend/solver/test/test_highs.c
+++ b/ascend/solver/test/test_highs.c
@@ -14,6 +14,10 @@
 #include <ascend/compiler/instquery.h>
 #include <ascend/compiler/initialize.h>
 #include <ascend/compiler/name.h>
+#include <ascend/compiler/parentchild.h>
+#include <ascend/compiler/atomvalue.h>
+#include <ascend/compiler/mathinst.h>
+#include <ascend/compiler/relation_util.h>
 #include <ascend/compiler/packages.h>
 
 #include <ascend/system/system.h>
@@ -56,9 +60,41 @@ static int find_solver_var_value(slv_system_t sys, const char *name_substr, doub
 	return 0;
 }
 
+static void check_lp1_instance_tree(struct Instance *root, double expected_objective){
+	struct Instance *x;
+	struct Instance *y;
+	struct Instance *s1;
+	struct Instance *s2;
+	struct Instance *obj;
+	const struct relation *objrel;
+
+	CU_ASSERT_FATAL(root != NULL);
+	x = ChildByChar(root,AddSymbol("x"));
+	y = ChildByChar(root,AddSymbol("y"));
+	s1 = ChildByChar(root,AddSymbol("s1"));
+	s2 = ChildByChar(root,AddSymbol("s2"));
+	obj = ChildByChar(root,AddSymbol("obj"));
+	CU_ASSERT_FATAL(x != NULL);
+	CU_ASSERT_FATAL(y != NULL);
+	CU_ASSERT_FATAL(s1 != NULL);
+	CU_ASSERT_FATAL(s2 != NULL);
+	CU_ASSERT_FATAL(obj != NULL);
+
+	CU_ASSERT_DOUBLE_EQUAL(2.0,RealAtomValue(x),1e-7);
+	CU_ASSERT_DOUBLE_EQUAL(2.0,RealAtomValue(y),1e-7);
+	CU_ASSERT_DOUBLE_EQUAL(0.0,RealAtomValue(s1),1e-7);
+	CU_ASSERT_DOUBLE_EQUAL(0.0,RealAtomValue(s2),1e-7);
+
+	objrel = GetInstanceRelationOnly(obj);
+	CU_ASSERT_FATAL(objrel != NULL);
+	CU_ASSERT_DOUBLE_EQUAL(expected_objective,RelationResidual(objrel),1e-7);
+}
+
 static void run_highs_model(
 	const char *module_path,
 	const char *model_name,
+	double expected_objective,
+	int check_scalars_in_tree,
 	const struct var_expect *vars,
 	int nvars
 ){
@@ -128,6 +164,20 @@ static void run_highs_model(
 		}
 		CU_ASSERT_DOUBLE_EQUAL(vars[i].expected,value,vars[i].tol);
 	}
+	{
+		struct Instance *root = GetSimulationRoot(siminst);
+		struct Instance *objinst;
+		struct rel_relation *objrel = slv_get_obj_relation(sys);
+		CU_ASSERT_FATAL(root != NULL);
+		CU_ASSERT_FATAL(objrel != NULL);
+		objinst = ChildByChar(root,AddSymbol("obj"));
+		CU_ASSERT_FATAL(objinst != NULL);
+		CU_ASSERT_DOUBLE_EQUAL(expected_objective,rel_residual(objrel),1e-7);
+		CU_ASSERT_DOUBLE_EQUAL(expected_objective,RelationResidual(GetInstanceRelationOnly(objinst)),1e-7);
+		if(check_scalars_in_tree){
+			check_lp1_instance_tree(root,expected_objective);
+		}
+	}
 
 cleanup:
 	if(sys)system_destroy(sys);
@@ -144,7 +194,7 @@ static void test_highs_lp1(void){
 		{"s1", 0.0, 1e-7},
 		{"s2", 0.0, 1e-7}
 	};
-	run_highs_model("models/test/ipopt/lp1.a4c","lp1",expected,4);
+	run_highs_model("models/test/ipopt/lp1.a4c","lp1",-10.0,1,expected,4);
 }
 
 static void test_highs_lp_structured(void){
@@ -154,7 +204,7 @@ static void test_highs_lp_structured(void){
 		{"row[1].s", 0.0, 1e-7},
 		{"row[2].s", 0.0, 1e-7}
 	};
-	run_highs_model("models/test/ipopt/lp_structured.a4c","lp_structured",expected,4);
+	run_highs_model("models/test/ipopt/lp_structured.a4c","lp_structured",-10.0,0,expected,4);
 }
 
 #define TESTS(T) \

--- a/ascend/solver/test/test_ipopt.c
+++ b/ascend/solver/test/test_ipopt.c
@@ -153,7 +153,9 @@ static void test_ipopt(const char *filenamestem){
 	X T(test11) \
 	X T(test12) \
 	X T(test13) \
-	X T(test14)
+	X T(test14) \
+	X T(lp1) \
+	X T(lp_structured)
 //	X T(test15) --- FAILS, need to work out why
 // X T(formula) --- FAILS, need to work out why.
 

--- a/ascend/solver/test/test_makemps.c
+++ b/ascend/solver/test/test_makemps.c
@@ -1,0 +1,354 @@
+#include <string.h>
+#include <stdlib.h>
+#include <stdio.h>
+
+#include <ascend/general/env.h>
+#include <ascend/general/ospath.h>
+
+#include <ascend/utilities/ascEnvVar.h>
+
+#include <ascend/compiler/ascCompiler.h>
+#include <ascend/compiler/module.h>
+#include <ascend/compiler/parser.h>
+#include <ascend/compiler/library.h>
+#include <ascend/compiler/symtab.h>
+#include <ascend/compiler/simlist.h>
+#include <ascend/compiler/instquery.h>
+#include <ascend/compiler/initialize.h>
+#include <ascend/compiler/name.h>
+#include <ascend/compiler/packages.h>
+
+#include <ascend/system/system.h>
+#include <ascend/system/slv_client.h>
+#include <ascend/system/slv_param.h>
+#include <ascend/solver/solver.h>
+
+#include <test/common.h>
+
+static int find_param_index(const slv_parameters_t *pp, const char *name){
+	int i;
+	for(i=0; i<pp->num_parms; ++i){
+		if(pp->parms[i].name != NULL && 0 == strcmp(pp->parms[i].name, name)){
+			return i;
+		}
+	}
+	return -1;
+}
+
+static int file_contains(const char *path, const char *needle){
+	FILE *f = fopen(path, "rb");
+	char *buf;
+	long len;
+	int found;
+
+	if(!f)return 0;
+	if(0 != fseek(f,0,SEEK_END)){
+		fclose(f);
+		return 0;
+	}
+	len = ftell(f);
+	if(len < 0){
+		fclose(f);
+		return 0;
+	}
+	rewind(f);
+	buf = (char *)malloc((size_t)len + 1);
+	if(!buf){
+		fclose(f);
+		return 0;
+	}
+	if((size_t)len != fread(buf,1,(size_t)len,f)){
+		free(buf);
+		fclose(f);
+		return 0;
+	}
+	buf[len] = '\0';
+	found = strstr(buf, needle) != NULL;
+	free(buf);
+	fclose(f);
+	return found;
+}
+
+static void run_makemps_model(
+	const char *module_path,
+	const char *model_name,
+	const char *mpsfile,
+	const char *mapfile,
+	const char *map_needle_1,
+	const char *map_needle_2
+){
+	int solver_index = -1;
+	struct Instance *siminst = NULL;
+	slv_system_t sys = NULL;
+
+	remove(mpsfile);
+	remove(mapfile);
+
+	Asc_CompilerInit(1);
+	CU_TEST(0 == Asc_PutEnv(ASC_ENV_LIBRARY "=models"));
+	CU_TEST(0 == Asc_PutEnv(ASC_ENV_SOLVERS "=solvers/makemps"));
+
+	if(0 != package_load("makemps",NULL)){
+		CONSOLE_DEBUG("Skipping MakeMPS test: solver not available");
+		goto cleanup;
+	}
+	solver_index = slv_lookup_client("MakeMPS");
+	if(solver_index == -1){
+		CONSOLE_DEBUG("Skipping MakeMPS test: solver not registered");
+		goto cleanup;
+	}
+
+	{
+		int status;
+		Asc_OpenModule(module_path,&status);
+		CU_ASSERT_FATAL(status == 0);
+	}
+	CU_ASSERT(0 == zz_parse());
+	CU_ASSERT_FATAL(FindType(AddSymbol(model_name)) != NULL);
+
+	siminst = SimsCreateInstance(AddSymbol(model_name), AddSymbol("sim1"), e_normal, NULL);
+	CU_ASSERT_FATAL(siminst != NULL);
+
+	{
+		struct Name *name = CreateIdName(AddSymbol("on_load"));
+		enum Proc_enum pe = Initialize(GetSimulationRoot(siminst),name,"sim1", ASCERR, WP_STOPONERR, NULL, NULL);
+		CU_ASSERT(pe == Proc_all_ok);
+	}
+
+	sys = system_build(GetSimulationRoot(siminst));
+	CU_ASSERT_FATAL(sys != NULL);
+	CU_ASSERT_FATAL(slv_select_solver(sys,solver_index) != -1);
+
+		/* Configure export filename and keep strict linear mode. */
+		{
+			slv_parameters_t pp;
+			int filename_idx;
+			int nonlin_idx;
+		slv_get_parameters(sys, &pp);
+			filename_idx = find_param_index(&pp, "filename");
+			nonlin_idx = find_param_index(&pp, "nonlin");
+			CU_ASSERT_FATAL(filename_idx != -1);
+			CU_ASSERT_FATAL(nonlin_idx != -1);
+			slv_set_char_parameter(&(SLV_PARAM_CHAR(&pp,filename_idx)),mpsfile);
+			SLV_PARAM_BOOL(&pp,nonlin_idx) = FALSE;
+			slv_set_parameters(sys, &pp);
+		}
+
+		(void)slv_presolve(sys);
+		(void)slv_solve(sys);
+
+		CU_ASSERT_FATAL(file_contains(mpsfile, "ROWS"));
+	CU_ASSERT(file_contains(mpsfile, "COLUMNS"));
+	CU_ASSERT(file_contains(mpsfile, "RHS"));
+	CU_ASSERT(file_contains(mpsfile, "BOUNDS"));
+	CU_ASSERT(file_contains(mpsfile, "ENDATA"));
+	CU_ASSERT_FATAL(file_contains(mapfile, "ASCEND/MPS Variable Name Mapping"));
+	if(map_needle_1 != NULL){
+		CU_ASSERT_FATAL(file_contains(mapfile, map_needle_1));
+	}
+	if(map_needle_2 != NULL){
+		CU_ASSERT_FATAL(file_contains(mapfile, map_needle_2));
+	}
+
+cleanup:
+	if(sys)system_destroy(sys);
+	system_free_reused_mem();
+	solver_destroy_engines();
+	if(siminst)sim_destroy(siminst);
+	Asc_CompilerDestroy();
+	remove(mpsfile);
+	remove(mapfile);
+}
+
+static void test_makemps_lp1(void){
+	run_makemps_model(
+		"models/test/ipopt/lp1.a4c",
+		"lp1",
+		"test/makemps_lp1.mps",
+		"test/makemps_lp1.map",
+		NULL,
+		NULL
+	);
+}
+
+static void test_makemps_lp_structured(void){
+	run_makemps_model(
+		"models/test/ipopt/lp_structured.a4c",
+		"lp_structured",
+		"test/makemps_lp_structured.mps",
+		"test/makemps_lp_structured.map",
+		"x[1]",
+		"row[1].s"
+	);
+}
+
+static void test_makemps_rejects_nonlinear_default(void){
+	int solver_index = -1;
+	struct Instance *siminst = NULL;
+	slv_system_t sys = NULL;
+	slv_status_t status;
+	const char *mpsfile = "test/makemps_nonlinear_default.mps";
+	const char *mapfile = "test/makemps_nonlinear_default.map";
+
+	remove(mpsfile);
+	remove(mapfile);
+
+	Asc_CompilerInit(1);
+	CU_TEST(0 == Asc_PutEnv(ASC_ENV_LIBRARY "=models"));
+	CU_TEST(0 == Asc_PutEnv(ASC_ENV_SOLVERS "=solvers/makemps"));
+
+	if(0 != package_load("makemps",NULL)){
+		CONSOLE_DEBUG("Skipping MakeMPS nonlinear test: solver not available");
+		goto cleanup;
+	}
+	solver_index = slv_lookup_client("MakeMPS");
+	if(solver_index == -1){
+		CONSOLE_DEBUG("Skipping MakeMPS nonlinear test: solver not registered");
+		goto cleanup;
+	}
+
+	{
+		int status_open;
+		Asc_OpenModule("models/test/ipopt/test11.a4c",&status_open);
+		CU_ASSERT_FATAL(status_open == 0);
+	}
+	CU_ASSERT(0 == zz_parse());
+	CU_ASSERT_FATAL(FindType(AddSymbol("test11")) != NULL);
+
+	siminst = SimsCreateInstance(AddSymbol("test11"), AddSymbol("sim1"), e_normal, NULL);
+	CU_ASSERT_FATAL(siminst != NULL);
+
+	{
+		struct Name *name = CreateIdName(AddSymbol("on_load"));
+		enum Proc_enum pe = Initialize(GetSimulationRoot(siminst),name,"sim1", ASCERR, WP_STOPONERR, NULL, NULL);
+		CU_ASSERT(pe == Proc_all_ok);
+	}
+
+	sys = system_build(GetSimulationRoot(siminst));
+	CU_ASSERT_FATAL(sys != NULL);
+	CU_ASSERT_FATAL(slv_select_solver(sys,solver_index) != -1);
+
+	{
+		slv_parameters_t pp;
+		int filename_idx;
+		int nonlin_idx;
+		slv_get_parameters(sys, &pp);
+		filename_idx = find_param_index(&pp, "filename");
+		nonlin_idx = find_param_index(&pp, "nonlin");
+		CU_ASSERT_FATAL(filename_idx != -1);
+		CU_ASSERT_FATAL(nonlin_idx != -1);
+		slv_set_char_parameter(&(SLV_PARAM_CHAR(&pp,filename_idx)),mpsfile);
+		SLV_PARAM_BOOL(&pp,nonlin_idx) = FALSE;
+		slv_set_parameters(sys, &pp);
+	}
+
+	(void)slv_presolve(sys);
+	slv_get_status(sys,&status);
+	CU_ASSERT_FALSE(status.ready_to_solve);
+
+	(void)slv_solve(sys);
+	CU_ASSERT_FALSE(file_contains(mpsfile, "ROWS"));
+	CU_ASSERT_FALSE(file_contains(mapfile, "ASCEND/MPS Variable Name Mapping"));
+
+cleanup:
+	if(sys)system_destroy(sys);
+	system_free_reused_mem();
+	solver_destroy_engines();
+	if(siminst)sim_destroy(siminst);
+	Asc_CompilerDestroy();
+	remove(mpsfile);
+	remove(mapfile);
+}
+
+static void test_makemps_linearises_nonlinear_when_enabled(void){
+	int solver_index = -1;
+	struct Instance *siminst = NULL;
+	slv_system_t sys = NULL;
+	slv_status_t status;
+	const char *mpsfile = "test/makemps_nonlinear_enabled.mps";
+	const char *mapfile = "test/makemps_nonlinear_enabled.map";
+
+	remove(mpsfile);
+	remove(mapfile);
+
+	Asc_CompilerInit(1);
+	CU_TEST(0 == Asc_PutEnv(ASC_ENV_LIBRARY "=models"));
+	CU_TEST(0 == Asc_PutEnv(ASC_ENV_SOLVERS "=solvers/makemps"));
+
+	if(0 != package_load("makemps",NULL)){
+		CONSOLE_DEBUG("Skipping MakeMPS nonlinear-enabled test: solver not available");
+		goto cleanup;
+	}
+	solver_index = slv_lookup_client("MakeMPS");
+	if(solver_index == -1){
+		CONSOLE_DEBUG("Skipping MakeMPS nonlinear-enabled test: solver not registered");
+		goto cleanup;
+	}
+
+	{
+		int status_open;
+		Asc_OpenModule("models/test/ipopt/test11.a4c",&status_open);
+		CU_ASSERT_FATAL(status_open == 0);
+	}
+	CU_ASSERT(0 == zz_parse());
+	CU_ASSERT_FATAL(FindType(AddSymbol("test11")) != NULL);
+
+	siminst = SimsCreateInstance(AddSymbol("test11"), AddSymbol("sim1"), e_normal, NULL);
+	CU_ASSERT_FATAL(siminst != NULL);
+
+	{
+		struct Name *name = CreateIdName(AddSymbol("on_load"));
+		enum Proc_enum pe = Initialize(GetSimulationRoot(siminst),name,"sim1", ASCERR, WP_STOPONERR, NULL, NULL);
+		CU_ASSERT(pe == Proc_all_ok);
+	}
+
+	sys = system_build(GetSimulationRoot(siminst));
+	CU_ASSERT_FATAL(sys != NULL);
+	CU_ASSERT_FATAL(slv_select_solver(sys,solver_index) != -1);
+
+	{
+		slv_parameters_t pp;
+		int filename_idx;
+		int nonlin_idx;
+		slv_get_parameters(sys, &pp);
+		filename_idx = find_param_index(&pp, "filename");
+		nonlin_idx = find_param_index(&pp, "nonlin");
+		CU_ASSERT_FATAL(filename_idx != -1);
+		CU_ASSERT_FATAL(nonlin_idx != -1);
+		slv_set_char_parameter(&(SLV_PARAM_CHAR(&pp,filename_idx)),mpsfile);
+		SLV_PARAM_BOOL(&pp,nonlin_idx) = TRUE;
+		slv_set_parameters(sys, &pp);
+	}
+
+	(void)slv_presolve(sys);
+	slv_get_status(sys,&status);
+	CU_ASSERT_TRUE(status.ready_to_solve);
+
+	(void)slv_solve(sys);
+	CU_ASSERT_TRUE(file_contains(mpsfile, "ROWS"));
+	CU_ASSERT_TRUE(file_contains(mpsfile, "COLUMNS"));
+	CU_ASSERT_TRUE(file_contains(mpsfile, "RHS"));
+	CU_ASSERT_TRUE(file_contains(mpsfile, "BOUNDS"));
+	CU_ASSERT_TRUE(file_contains(mpsfile, "ENDATA"));
+	CU_ASSERT_TRUE(file_contains(mapfile, "ASCEND/MPS Variable Name Mapping"));
+	CU_ASSERT_TRUE(file_contains(mapfile, "x1"));
+	CU_ASSERT_TRUE(file_contains(mapfile, "x2"));
+	CU_ASSERT_TRUE(file_contains(mapfile, "x3"));
+
+cleanup:
+	if(sys)system_destroy(sys);
+	system_free_reused_mem();
+	solver_destroy_engines();
+	if(siminst)sim_destroy(siminst);
+	Asc_CompilerDestroy();
+	remove(mpsfile);
+	remove(mapfile);
+}
+
+#define TESTS(T) \
+	T(makemps_lp1) \
+	T(makemps_lp_structured) \
+	T(makemps_rejects_nonlinear_default) \
+	T(makemps_linearises_nonlinear_when_enabled)
+
+REGISTER_TESTS_SIMPLE(solver_makemps, TESTS)

--- a/ascend/solver/test/test_makemps.c
+++ b/ascend/solver/test/test_makemps.c
@@ -1,6 +1,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include <stdio.h>
+#include <math.h>
 
 #include <ascend/general/env.h>
 #include <ascend/general/ospath.h>
@@ -69,13 +70,209 @@ static int file_contains(const char *path, const char *needle){
 	return found;
 }
 
+struct highs_var_expect{
+	const char *ascend_substr;
+	double expected;
+	double tol;
+};
+
+static int highs_is_available(void){
+	static int cached = -1;
+	if(cached == -1){
+		cached = (system("highs --version >/dev/null 2>&1") == 0) ? 1 : 0;
+	}
+	return cached;
+}
+
+static int run_highs(const char *mpsfile, const char *solfile){
+	char cmd[1024];
+	if(snprintf(cmd,sizeof(cmd)
+		,"highs --model_file \"%s\" --solution_file \"%s\" >/dev/null 2>&1"
+		,mpsfile,solfile
+	) >= (int)sizeof(cmd)){
+		return 0;
+	}
+	return system(cmd) == 0;
+}
+
+static int highs_solution_is_optimal(const char *solfile){
+	FILE *f;
+	char line[512];
+	int saw_model_status = 0;
+
+	f = fopen(solfile,"r");
+	if(!f)return 0;
+	while(fgets(line,sizeof(line),f)){
+		if(saw_model_status){
+			fclose(f);
+			return strncmp(line,"Optimal",7) == 0;
+		}
+		if(strncmp(line,"Model status",12) == 0){
+			saw_model_status = 1;
+		}
+	}
+	fclose(f);
+	return 0;
+}
+
+static int highs_solution_objective(const char *solfile, double *objective){
+	FILE *f;
+	char line[512];
+	double v;
+
+	f = fopen(solfile,"r");
+	if(!f)return 0;
+	while(fgets(line,sizeof(line),f)){
+		if(sscanf(line,"Objective %lf",&v) == 1){
+			*objective = v;
+			fclose(f);
+			return 1;
+		}
+	}
+	fclose(f);
+	return 0;
+}
+
+static int map_lookup_mps_name(const char *mapfile, const char *ascend_substr, char *mps_name, size_t mps_name_len){
+	FILE *f;
+	char line[1024];
+	char tok[64];
+
+	f = fopen(mapfile,"r");
+	if(!f)return 0;
+	while(fgets(line,sizeof(line),f)){
+		if(sscanf(line,"%63s",tok) == 1 && tok[0] == 'C' && strstr(line,ascend_substr) != NULL){
+			(void)snprintf(mps_name,mps_name_len,"%s",tok);
+			fclose(f);
+			return 1;
+		}
+	}
+	fclose(f);
+	return 0;
+}
+
+static int highs_solution_col_value(const char *solfile, const char *col_name, double *value){
+	FILE *f;
+	char line[512];
+	char name[128];
+	double v;
+	int in_primal = 0;
+	int in_columns = 0;
+
+	f = fopen(solfile,"r");
+	if(!f)return 0;
+	while(fgets(line,sizeof(line),f)){
+		if(strncmp(line,"# Primal solution values",24) == 0){
+			in_primal = 1;
+			continue;
+		}
+		if(in_primal && strncmp(line,"# Dual solution values",22) == 0){
+			break;
+		}
+		if(in_primal && strncmp(line,"# Columns",9) == 0){
+			in_columns = 1;
+			continue;
+		}
+		if(in_primal && in_columns){
+			if(line[0] == '#'){
+				if(strncmp(line,"# Rows",6) == 0){
+					in_columns = 0;
+				}
+				continue;
+			}
+			if(sscanf(line,"%127s %lf",name,&v) == 2 && 0 == strcmp(name,col_name)){
+				*value = v;
+				fclose(f);
+				return 1;
+			}
+		}
+	}
+	fclose(f);
+	return 0;
+}
+
+static void check_highs_solution(
+	const char *mpsfile,
+	const char *mapfile,
+	double expected_objective,
+	const struct highs_var_expect *vars,
+	int nvars
+){
+	char solfile[512];
+	double obj = 0.0;
+	int i;
+	int ok = 1;
+
+	if(!highs_is_available()){
+		CONSOLE_DEBUG("Skipping HiGHS checks: 'highs' not found in PATH");
+		return;
+	}
+
+	if(snprintf(solfile,sizeof(solfile),"%s.highs.sol",mpsfile) >= (int)sizeof(solfile)){
+		CU_FAIL("HiGHS solution filename overflow");
+		ok = 0;
+		goto cleanup;
+	}
+	remove(solfile);
+
+	if(!run_highs(mpsfile,solfile)){
+		CU_FAIL("HiGHS execution failed");
+		ok = 0;
+		goto cleanup;
+	}
+	if(!highs_solution_is_optimal(solfile)){
+		CU_FAIL("HiGHS did not report optimal status");
+		ok = 0;
+		goto cleanup;
+	}
+	if(!highs_solution_objective(solfile,&obj)){
+		CU_FAIL("Unable to parse HiGHS objective");
+		ok = 0;
+		goto cleanup;
+	}
+	CONSOLE_DEBUG("HiGHS objective for %s: %.12g",mpsfile,obj);
+	CU_ASSERT_DOUBLE_EQUAL(expected_objective,obj,1e-7);
+	if(fabs(expected_objective - obj) > 1e-7){
+		ok = 0;
+		goto cleanup;
+	}
+
+	for(i = 0; i < nvars; ++i){
+		char mps_name[64];
+		double value = 0.0;
+		if(!map_lookup_mps_name(mapfile,vars[i].ascend_substr,mps_name,sizeof(mps_name))){
+			CU_FAIL("Unable to map ASCEND variable name to MPS column name");
+			ok = 0;
+			break;
+		}
+		if(!highs_solution_col_value(solfile,mps_name,&value)){
+			CU_FAIL("Unable to parse HiGHS primal column value");
+			ok = 0;
+			break;
+		}
+		CONSOLE_DEBUG("HiGHS %s (%s) = %.12g",vars[i].ascend_substr,mps_name,value);
+		CU_ASSERT_DOUBLE_EQUAL(vars[i].expected,value,vars[i].tol);
+		if(fabs(vars[i].expected - value) > fabs(vars[i].tol)){
+			ok = 0;
+			break;
+		}
+	}
+
+cleanup:
+	remove(solfile);
+	(void)ok;
+}
+
 static void run_makemps_model(
 	const char *module_path,
 	const char *model_name,
 	const char *mpsfile,
 	const char *mapfile,
 	const char *map_needle_1,
-	const char *map_needle_2
+	const char *map_needle_2,
+	double highs_expected_objective,
+	const struct highs_var_expect *highs_vars,
+	int highs_nvars
 ){
 	int solver_index = -1;
 	struct Instance *siminst = NULL;
@@ -149,6 +346,7 @@ static void run_makemps_model(
 	if(map_needle_2 != NULL){
 		CU_ASSERT_FATAL(file_contains(mapfile, map_needle_2));
 	}
+	check_highs_solution(mpsfile,mapfile,highs_expected_objective,highs_vars,highs_nvars);
 
 cleanup:
 	if(sys)system_destroy(sys);
@@ -161,24 +359,42 @@ cleanup:
 }
 
 static void test_makemps_lp1(void){
+	static const struct highs_var_expect expected_vars[] = {
+		{".x", 2.0, 1e-7},
+		{".y", 2.0, 1e-7},
+		{".s1", 0.0, 1e-7},
+		{".s2", 0.0, 1e-7}
+	};
 	run_makemps_model(
 		"models/test/ipopt/lp1.a4c",
 		"lp1",
 		"test/makemps_lp1.mps",
 		"test/makemps_lp1.map",
 		NULL,
-		NULL
+		NULL,
+		-10.0,
+		expected_vars,
+		4
 	);
 }
 
 static void test_makemps_lp_structured(void){
+	static const struct highs_var_expect expected_vars[] = {
+		{"x[1]", 2.0, 1e-7},
+		{"x[2]", 2.0, 1e-7},
+		{"row[1].s", 0.0, 1e-7},
+		{"row[2].s", 0.0, 1e-7}
+	};
 	run_makemps_model(
 		"models/test/ipopt/lp_structured.a4c",
 		"lp_structured",
 		"test/makemps_lp_structured.mps",
 		"test/makemps_lp_structured.map",
 		"x[1]",
-		"row[1].s"
+		"row[1].s",
+		-10.0,
+		expected_vars,
+		4
 	);
 }
 

--- a/ascend/solver/test/test_register_solver.c
+++ b/ascend/solver/test/test_register_solver.c
@@ -24,6 +24,7 @@
 	T(ipopt) \
 	T(conopt) \
 	T(makemps) \
+	T(highs) \
 	T(qrslv) \
 	T(fprops) \
 	T(lrslv) \

--- a/ascend/solver/test/test_register_solver.c
+++ b/ascend/solver/test/test_register_solver.c
@@ -23,6 +23,7 @@
 	T(slvreq) \
 	T(ipopt) \
 	T(conopt) \
+	T(makemps) \
 	T(qrslv) \
 	T(fprops) \
 	T(lrslv) \

--- a/ascend/system/relman.c
+++ b/ascend/system/relman.c
@@ -108,23 +108,120 @@ void relman_free_reused_mem(void){
 }
 
 
-#if REIMPLEMENT
 boolean relman_is_linear( struct rel_relation *rel, var_filter_t *filter){
-   return (
-      exprman_is_linear(rel,rel_lhs(rel),filter) &&
-      exprman_is_linear(rel,rel_rhs(rel),filter)
-   );
+   const struct var_variable **vlist;
+   ltmatrix *hess;
+   int32 len, i, j;
+   int32 status;
+   double hij;
+   const double tol = 1e-12;
+
+   if(rel == NULL || filter == NULL){
+      return FALSE;
+   }
+
+   len = rel_n_incidences(rel);
+   if(len <= 1){
+      return TRUE;
+   }
+
+   vlist = rel_incidence_list(rel);
+   hess = ltmatrix_create(LTMATRIX_LOWER,len);
+   if(hess == NULL){
+      return FALSE;
+   }
+
+   status = (int32)RelationCalcHessianMtxSafe(rel_instance(rel),hess,len);
+   if(status != 0){
+      ltmatrix_destroy(hess);
+      return FALSE;
+   }
+
+   for(i = 0; i < len; ++i){
+      if(!var_apply_filter(vlist[i],filter)){
+         continue;
+      }
+      for(j = 0; j <= i; ++j){
+         if(!var_apply_filter(vlist[j],filter)){
+            continue;
+         }
+         hij = ltmatrix_get_element(hess,i,j);
+         if(fabs(hij) > tol){
+            ltmatrix_destroy(hess);
+            return FALSE;
+         }
+      }
+   }
+
+   ltmatrix_destroy(hess);
+   return TRUE;
 }
 
 real64 relman_linear_coef(struct rel_relation *rel, struct var_variable *var
 		, var_filter_t *filter
 ){
-   return(
-      exprman_linear_coef(rel,rel_lhs(rel),var,filter) -
-      exprman_linear_coef(rel,rel_rhs(rel),var,filter)
-   );
+   struct var_variable **vars;
+   real64 *derivs;
+   real64 resid;
+   real64 sum;
+   int32 len, count, i;
+   int32 status;
+   int32 calc_okp = 1;
+
+   if(rel == NULL || filter == NULL){
+      return 0.0;
+   }
+
+   len = rel_n_incidences(rel);
+   if(len <= 0){
+      return (var == NULL ? -relman_eval(rel,&calc_okp,0) : 0.0);
+   }
+
+   derivs = ASC_NEW_ARRAY_OR_NULL(real64,len);
+   vars = ASC_NEW_ARRAY_OR_NULL(struct var_variable *,len);
+   if(derivs == NULL || vars == NULL){
+      if(derivs)ASC_FREE(derivs);
+      if(vars)ASC_FREE(vars);
+      return 0.0;
+   }
+
+   count = 0;
+   status = relman_diff3(rel,filter,derivs,vars,&count,0);
+   if(status != 0){
+      ASC_FREE(derivs);
+      ASC_FREE(vars);
+      return 0.0;
+   }
+
+   if(var != NULL){
+      for(i = 0; i < count; ++i){
+         if(vars[i] == var){
+            real64 d = derivs[i];
+            ASC_FREE(derivs);
+            ASC_FREE(vars);
+            return d;
+         }
+      }
+      ASC_FREE(derivs);
+      ASC_FREE(vars);
+      return 0.0;
+   }
+
+   resid = relman_eval(rel,&calc_okp,0);
+   if(!calc_okp){
+      ASC_FREE(derivs);
+      ASC_FREE(vars);
+      return 0.0;
+   }
+   sum = 0.0;
+   for(i = 0; i < count; ++i){
+      sum += derivs[i] * var_value(vars[i]);
+   }
+
+   ASC_FREE(derivs);
+   ASC_FREE(vars);
+   return sum - resid;
 }
-#endif
 
 
 #if 0 && KILL
@@ -1155,4 +1252,3 @@ char *relman_make_vstring_postfix(slv_system_t sys,
 }
 
 /* vim: set ts=2 et: */
-

--- a/ascend/system/relman.h
+++ b/ascend/system/relman.h
@@ -44,7 +44,8 @@
 	@{
 */
 
-#define relman_is_linear(a,b) (FALSE)
+ASC_DLLSPEC boolean relman_is_linear(struct rel_relation *rel,
+                                     var_filter_t *filter);
 /**<
  *  Determines whether or not the given relation is linear in
  *  all of the variables which pass through the variable filter, treating
@@ -458,4 +459,3 @@ extern void relman_free_reused_mem(void);
 /* @} */
 
 #endif  /* ASC_RELMAN_H */
-

--- a/ascend/system/var.c
+++ b/ascend/system/var.c
@@ -228,7 +228,7 @@ real64 var_lower_bound(struct var_variable *var)
   return( RealAtomValue(c) );
 }
 
-void var_set_lower_bound(struct var_variable *var, real64 lower_bound)
+ASC_DLLSPEC void var_set_lower_bound(struct var_variable *var, real64 lower_bound)
 {
   struct Instance *c;
   if (var==NULL || var->ratom==NULL) {
@@ -260,7 +260,7 @@ real64 var_upper_bound(struct var_variable *var)
   return( RealAtomValue(c) );
 }
 
-void var_set_upper_bound(struct var_variable *var, real64 upper_bound)
+ASC_DLLSPEC void var_set_upper_bound(struct var_variable *var, real64 upper_bound)
 {
   struct Instance *c;
   if (var==NULL || var->ratom==NULL) {
@@ -335,7 +335,7 @@ void var_set_fixed(struct var_variable *var, uint32 fixed)
   var_set_flagbit(var,VAR_FIXED,fixed);
 }
 
-uint32 var_relaxed(struct var_variable *var)
+ASC_DLLSPEC uint32 var_relaxed(struct var_variable *var)
 {
   struct Instance *c;
   if (var==NULL || var->ratom==NULL) {
@@ -616,4 +616,3 @@ boolean solver_semi( SlvBackendToken inst)
   type = InstanceTypeDesc(IPTR(inst));
   return( type == MoreRefined(type,g_solver_semi_type) );
 }
-

--- a/ascend/system/var.h
+++ b/ascend/system/var.h
@@ -326,14 +326,14 @@ ASC_DLLSPEC void var_set_nominal(struct var_variable *var, real64 nominal);
 
 ASC_DLLSPEC real64 var_lower_bound(struct var_variable *var);
 /**<  Returns the lower bound value of the variable. */
-extern void var_set_lower_bound(struct var_variable *var, real64 lower_bound);
+ASC_DLLSPEC void var_set_lower_bound(struct var_variable *var, real64 lower_bound);
 /**<
 	Sets the lower bound value of the variable.
 */
 
 ASC_DLLSPEC real64 var_upper_bound(struct var_variable *var);
 /**<  Returns the upper bound value of the variable. */
-extern void var_set_upper_bound(struct var_variable *var, real64 upper_bound);
+ASC_DLLSPEC void var_set_upper_bound(struct var_variable *var, real64 upper_bound);
 /**<
 	Gets/sets the upper bound value of the variable.
 */
@@ -491,7 +491,7 @@ ASC_DLLSPEC uint32 var_fixed(struct var_variable *var);
 /**< Returns the fixed flag of var.  Has side effects in the ascend instance. */
 ASC_DLLSPEC void var_set_fixed(struct var_variable *var, uint32 fixed);
 /**< Sets the fixed flag of var.  Has side effects in the ascend instance. */
-extern uint32 var_relaxed(struct var_variable *var);
+ASC_DLLSPEC uint32 var_relaxed(struct var_variable *var);
 /**< Returns the relaxed flag of var.  Has side effects in the ascend instance. */
 extern void var_set_relaxed(struct var_variable *var, uint32 fixed);
 /**< Sets the relaxed flag of var.  Has side effects in the ascend instance. */
@@ -675,4 +675,3 @@ extern boolean set_solver_types(void);
 /* @} */
 
 #endif  /* ASC_VAR_H */
-

--- a/models/test/conopt/lp1.a4c
+++ b/models/test/conopt/lp1.a4c
@@ -1,0 +1,39 @@
+REQUIRE "atoms.a4l";
+IMPORT "conopt";
+
+MODEL lp1;
+	x, y, s1, s2 IS_A factor;
+
+	c1: x + y + s1 = 4;
+	c2: x + s2 = 2;
+	obj: MINIMIZE -3*x -2*y;
+
+METHODS
+
+METHOD self_test;
+	ASSERT abs(x - 2) < 1e-7;
+	ASSERT abs(y - 2) < 1e-7;
+	ASSERT abs(s1) < 1e-7;
+	ASSERT abs(s2) < 1e-7;
+END self_test;
+
+METHOD bound_self;
+	x.lower_bound := 0;
+	y.lower_bound := 0;
+	s1.lower_bound := 0;
+	s2.lower_bound := 0;
+END bound_self;
+
+METHOD default_self;
+	x := 0.5;
+	y := 0.5;
+	s1 := 3.0;
+	s2 := 1.5;
+END default_self;
+
+METHOD on_load;
+	RUN bound_self;
+	RUN default_self;
+END on_load;
+
+END lp1;

--- a/models/test/conopt/lp_structured.a4c
+++ b/models/test/conopt/lp_structured.a4c
@@ -1,0 +1,73 @@
+REQUIRE "atoms.a4l";
+IMPORT "conopt";
+
+MODEL lp_row(
+	x1 WILL_BE factor;
+	x2 WILL_BE factor;
+	a1 WILL_BE factor_constant;
+	a2 WILL_BE factor_constant;
+	rhs WILL_BE factor_constant;
+);
+	s IS_A factor;
+	eqn: a1*x1 + a2*x2 + s = rhs;
+METHODS
+METHOD bound_self;
+	s.lower_bound := 0;
+END bound_self;
+END lp_row;
+
+MODEL lp_structured;
+	x[1..2] IS_A factor;
+	c[1..2] IS_A factor_constant;
+	a[1..2][1..2] IS_A factor_constant;
+	b[1..2] IS_A factor_constant;
+
+	c[1] :== -3;
+	c[2] :== -2;
+
+	a[1][1] :== 1;
+	a[1][2] :== 1;
+	b[1] :== 4;
+
+	a[2][1] :== 1;
+	a[2][2] :== 0;
+	b[2] :== 2;
+
+	FOR i IN [1..2] CREATE
+		row[i] IS_A lp_row(x[1], x[2], a[i][1], a[i][2], b[i]);
+	END FOR;
+
+	obj: MINIMIZE SUM[c[j]*x[j] | j IN [1..2]];
+
+METHODS
+
+METHOD self_test;
+	ASSERT abs(x[1] - 2) < 1e-7;
+	ASSERT abs(x[2] - 2) < 1e-7;
+	FOR i IN [1..2] DO
+		ASSERT abs(row[i].s) < 1e-7;
+	END FOR;
+END self_test;
+
+METHOD bound_self;
+	FOR j IN [1..2] DO
+		x[j].lower_bound := 0;
+	END FOR;
+	FOR i IN [1..2] DO
+		RUN row[i].bound_self;
+	END FOR;
+END bound_self;
+
+METHOD default_self;
+	x[1] := 0.5;
+	x[2] := 0.5;
+	row[1].s := 3.0;
+	row[2].s := 1.5;
+END default_self;
+
+METHOD on_load;
+	RUN bound_self;
+	RUN default_self;
+END on_load;
+
+END lp_structured;

--- a/models/test/ipopt/lp1.a4c
+++ b/models/test/ipopt/lp1.a4c
@@ -1,0 +1,38 @@
+REQUIRE "atoms.a4l";
+
+MODEL lp1;
+	x, y, s1, s2 IS_A factor;
+
+	c1: x + y + s1 = 4;
+	c2: x + s2 = 2;
+	obj: MINIMIZE -3*x -2*y;
+
+METHODS
+
+METHOD self_test;
+	ASSERT abs(x - 2) < 1e-7;
+	ASSERT abs(y - 2) < 1e-7;
+	ASSERT abs(s1) < 1e-7;
+	ASSERT abs(s2) < 1e-7;
+END self_test;
+
+METHOD bound_self;
+	x.lower_bound := 0;
+	y.lower_bound := 0;
+	s1.lower_bound := 0;
+	s2.lower_bound := 0;
+END bound_self;
+
+METHOD default_self;
+	x := 0.5;
+	y := 0.5;
+	s1 := 3.0;
+	s2 := 1.5;
+END default_self;
+
+METHOD on_load;
+	RUN bound_self;
+	RUN default_self;
+END on_load;
+
+END lp1;

--- a/models/test/ipopt/lp_structured.a4c
+++ b/models/test/ipopt/lp_structured.a4c
@@ -1,0 +1,72 @@
+REQUIRE "atoms.a4l";
+
+MODEL lp_row(
+	x1 WILL_BE factor;
+	x2 WILL_BE factor;
+	a1 WILL_BE factor_constant;
+	a2 WILL_BE factor_constant;
+	rhs WILL_BE factor_constant;
+);
+	s IS_A factor;
+	eqn: a1*x1 + a2*x2 + s = rhs;
+METHODS
+METHOD bound_self;
+	s.lower_bound := 0;
+END bound_self;
+END lp_row;
+
+MODEL lp_structured;
+	x[1..2] IS_A factor;
+	c[1..2] IS_A factor_constant;
+	a[1..2][1..2] IS_A factor_constant;
+	b[1..2] IS_A factor_constant;
+
+	c[1] :== -3;
+	c[2] :== -2;
+
+	a[1][1] :== 1;
+	a[1][2] :== 1;
+	b[1] :== 4;
+
+	a[2][1] :== 1;
+	a[2][2] :== 0;
+	b[2] :== 2;
+
+	FOR i IN [1..2] CREATE
+		row[i] IS_A lp_row(x[1], x[2], a[i][1], a[i][2], b[i]);
+	END FOR;
+
+	obj: MINIMIZE SUM[c[j]*x[j] | j IN [1..2]];
+
+METHODS
+
+METHOD self_test;
+	ASSERT abs(x[1] - 2) < 1e-7;
+	ASSERT abs(x[2] - 2) < 1e-7;
+	FOR i IN [1..2] DO
+		ASSERT abs(row[i].s) < 1e-7;
+	END FOR;
+END self_test;
+
+METHOD bound_self;
+	FOR j IN [1..2] DO
+		x[j].lower_bound := 0;
+	END FOR;
+	FOR i IN [1..2] DO
+		RUN row[i].bound_self;
+	END FOR;
+END bound_self;
+
+METHOD default_self;
+	x[1] := 0.5;
+	x[2] := 0.5;
+	row[1].s := 3.0;
+	row[2].s := 1.5;
+END default_self;
+
+METHOD on_load;
+	RUN bound_self;
+	RUN default_self;
+END on_load;
+
+END lp_structured;

--- a/solvers/SConscript
+++ b/solvers/SConscript
@@ -1,7 +1,7 @@
 Import('env')
 
 subdirs = [
-	'qrslv','conopt','cmslv','lrslv','lsode','ida','ipopt','dopri5','makemps','radau5'
+	'qrslv','conopt','cmslv','lrslv','lsode','ida','ipopt','dopri5','makemps','highs','radau5'
 ]
 #'tron',
 

--- a/solvers/highs/SConscript
+++ b/solvers/highs/SConscript
@@ -1,0 +1,58 @@
+Import('env')
+import subprocess, shutil, pathlib
+
+highs_test_text = """
+#include <interfaces/highs_c_api.h>
+int main(void){
+	void *h = Highs_create();
+	if(h)Highs_destroy(h);
+	return 0;
+}
+"""
+
+def CheckHIGHS(context):
+	context.Message('Checking for HiGHS... ')
+	pkg = shutil.which("pkg-config")
+	if pkg is None:
+		context.Result('no (pkg-config not found)')
+		return False
+	try:
+		subprocess.run([pkg,"--libs","--cflags","highs"],stdout=subprocess.PIPE,stderr=subprocess.PIPE,check=True)
+	except Exception:
+		context.Result('no (pkg-config --exists highs failed)')
+		return False
+
+	context.env.ParseConfig(str(pathlib.Path(pkg))+' --cflags --libs highs')
+	is_ok = context.TryLink(highs_test_text,".c")
+	if is_ok:
+		context.env.Append(CPPDEFINES='ASC_WITH_HIGHS')
+		context.Result(True)
+	else:
+		context.Result('no (failed to link)')
+	return is_ok
+
+if env.get('WITH_HIGHS'):
+	solver_env = env.Clone()
+	if env['HIGHS_PREFIX'] not in ['/usr']:
+		solver_env.AppendENVPath('PKG_CONFIG_PATH',env.subst("$HIGHS_PREFIX/lib/pkgconfig"))
+
+	conf = solver_env.Configure(custom_tests={'CheckHIGHS':CheckHIGHS})
+	if not conf.CheckHIGHS():
+		conf.env['WITH_HIGHS'] = False
+	solver_env = conf.Finish()
+
+	env.set_optional('highs',active=solver_env['WITH_HIGHS'],reason='not found')
+
+	if solver_env['WITH_HIGHS']:
+		solver_env.Append(LIBS=['ascend'],LIBPATH=['#'])
+		lib = solver_env.SharedLibrary('highs',['highs.c']
+			,SHLIBSUFFIX = env['EXTLIB_SUFFIX']
+			,SHLIBPREFIX = env['EXTLIB_PREFIX']
+		)
+		env.Depends(lib,env['libascend'])
+		env['extfns'] += [lib]
+		if env.get('CAN_INSTALL'):
+			dir = Dir(env.subst("$INSTALL_ROOT$INSTALL_SOLVERS"))
+			env.InstallShared(dir,lib)
+	else:
+		print('Skipping... HiGHS solver won\'t be built.')

--- a/solvers/highs/SConscript
+++ b/solvers/highs/SConscript
@@ -17,7 +17,7 @@ def CheckHIGHS(context):
 		context.Result('no (pkg-config not found)')
 		return False
 	try:
-		subprocess.run([pkg,"--libs","--cflags","highs"],stdout=subprocess.PIPE,stderr=subprocess.PIPE,check=True)
+		subprocess.run([pkg,"--exists","highs"],stdout=subprocess.PIPE,stderr=subprocess.PIPE,check=True)
 	except Exception:
 		context.Result('no (pkg-config --exists highs failed)')
 		return False
@@ -34,7 +34,8 @@ def CheckHIGHS(context):
 if env.get('WITH_HIGHS'):
 	solver_env = env.Clone()
 	if env['HIGHS_PREFIX'] not in ['/usr']:
-		solver_env.AppendENVPath('PKG_CONFIG_PATH',env.subst("$HIGHS_PREFIX/lib/pkgconfig"))
+		for subdir in ("lib/pkgconfig","lib64/pkgconfig"):
+			solver_env.AppendENVPath('PKG_CONFIG_PATH',env.subst(f"$HIGHS_PREFIX/{subdir}"))
 
 	conf = solver_env.Configure(custom_tests={'CheckHIGHS':CheckHIGHS})
 	if not conf.CheckHIGHS():

--- a/solvers/highs/highs.c
+++ b/solvers/highs/highs.c
@@ -1487,7 +1487,7 @@ void highs_presolve(slv_system_t server){
    if( sys->vlist_user == NULL ) determine_vlist(sys);
 #else
    if( sys->vlist_user == NULL ){
-     ERROR_REPORTER_HERE(ASC_PROG_ERR,"(highs) determine_vlist is broken.");
+     ERROR_REPORTER_HERE(ASC_PROG_ERR,"automatic variable-list setup is broken.");
      exit(1);
    }
 #endif
@@ -1611,7 +1611,7 @@ void highs_presolve(slv_system_t server){
                                  &sys->mps.rank,
                                  &sys->mps.bcol);
    if( sys->mps.Ac_mtx == NULL ) {
-      ERROR_REPORTER_HERE(ASC_PROG_ERR,"call to calc_matrix failed.");
+      ERROR_REPORTER_HERE(ASC_PROG_ERR,"failed to build matrix representation.");
       nuke_pointers(sys->mps);
       return;
    }

--- a/solvers/highs/highs.c
+++ b/solvers/highs/highs.c
@@ -1,0 +1,2185 @@
+/*
+ *  MPS: Ascend MPS file generator
+ *  by Craig Schmidt
+ *  Created: 2/11/95
+ *  Version: $Revision: 1.29 $
+ *  Version control file: $RCSfile: slv6.c,v $
+ *  Date last modified: $Date: 2000/01/25 02:27:38 $
+ *  Last modified by: $Author: ballan $
+ *
+ *  This file is part of the SLV solver.
+ *
+ *  Copyright (C) 1990 Karl Michael Westerberg
+ *  Copyright (C) 1993 Joseph Zaher
+ *  Copyright (C) 1994 Joseph Zaher, Benjamin Andrew Allan
+ *  Copyright (C) 1995 Craig Schmidt
+ *
+ *  The SLV solver is free software; you can redistribute
+ *  it and/or modify it under the terms of the GNU General Public License as
+ *  published by the Free Software Foundation; either version 2 of the
+ *  License, or (at your option) any later version.
+ *
+ *  The SLV solver is distributed in hope that it will be
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/*  known bugs
+ *  still uses pl_ functions and assumes the old slv protocol.
+ */
+
+#include "highs.h"
+
+#include <ascend/general/ascMalloc.h>
+#include <ascend/utilities/set.h>
+#include <ascend/general/mem.h>
+#include <ascend/general/tm_time.h>
+#include <ascend/general/list.h>
+#include <ascend/general/dstring.h>
+#include <ascend/compiler/module.h>
+#include <ascend/compiler/library.h>
+#include <ascend/compiler/instance_io.h>
+#include <ascend/compiler/instquery.h>
+#include <string.h>
+
+#include <ascend/linear/mtx.h>
+
+#include <ascend/system/calc.h>
+#include <ascend/system/relman.h>
+#include <ascend/system/slv_common.h>
+#include <ascend/system/bnd.h>
+#include <ascend/system/var.h>
+#include <ascend/system/rel.h>
+#include <interfaces/highs_c_api.h>
+
+#ifndef KILL
+#define KILL TRUE
+#endif
+#define DEBUG FALSE
+
+#define SYS(s) ((highs_system_t)(s))
+
+ASC_DLLSPEC SolverRegisterFn highs_register;
+
+/* HiGHS 1.13.1 header declares this static symbol without defining it. */
+static const char* Highs_compilationDate(void){ return ""; }
+static void highs_link_capi_stubs(void){ (void)Highs_compilationDate(); }
+
+struct highs_system_structure {
+
+   /**
+    ***  Problem definition
+    **/
+   slv_system_t           slv;          /* slv_system_t back-link */
+   struct rel_relation    *obj;          /* Objective function: NULL = none */
+   struct var_variable    **vlist;       /* Variable list (NULL terminated) */
+   struct var_variable    **vlist_user;  /* User vlist (NULL = determine) */
+   struct bnd_boundary    *blist;       /* Boundary list (NULL terminated) */
+   struct bnd_boundary    *blist_user;  /* User blist (NULL = none) */
+   struct rel_relation    **rlist;       /* Relation list (NULL terminated) */
+   struct rel_relation    **rlist_user;  /* User rlist (NULL = none) */
+   struct ExtRelCache     **erlist;     /* External relations cache list */
+   struct ExtRelCache     **erlist_user;/* User erlist (NULL = none) */
+
+   /**
+    ***  Solver information
+    **/
+   int                    integrity;    /* ? Has the system been created */
+
+   slv_parameters_t       p;            /* Parameters */
+   struct slv_parameter pa[SP6_PARAMS];
+
+   slv_status_t           s;            /* Status flags */
+   double                 clock;        /* CPU time */
+
+   /**
+    ***  Calculated Data
+    ***
+    **/
+   mps_data_t  mps;          /* the main chunk of data for the problem */
+
+};
+
+
+static int highs_get_default_parameters(slv_system_t server, SlvClientToken asys
+		,slv_parameters_t *parameters
+){
+	struct slv_parameter *new_parms = NULL;
+
+	(void)server;
+	(void)asys;
+	highs_link_capi_stubs();
+
+	if(parameters->parms == NULL) {
+		new_parms = ASC_NEW_ARRAY_OR_NULL(struct slv_parameter,SP6_PARAMS);
+		if(new_parms == NULL) {
+		    return -1;
+		}
+		parameters->parms = new_parms;
+		parameters->dynamic_parms = 1;
+	}
+
+	parameters->num_parms = 0;
+
+	/** ASCEND Options */
+
+	slv_param_bool(parameters,ASCEND_PARAM_SAFEEVAL
+		,(SlvParameterInitBool){{"safeeval"
+			,"Use safe evaluation?",1
+			,"Use 'safe' function evaluation routines (TRUE) or allow ASCEND to "
+			"throw SIGFPE errors which will then halt integration (FALSE)."
+		}, FALSE}
+	);
+
+	/** Integer and Bool Options */
+
+	slv_param_bool(parameters,SP6_NONLIN
+		,(SlvParameterInitBool){{"nonlin"
+			,"Linearise non-linear equations?",1
+			,"Perform linearisation of non-linear models at the current point (TRUE)"
+			" or else require a linear model (FALSE)."
+		}, FALSE}
+	);
+
+
+	slv_param_bool(parameters,SP6_RELAXED
+		,(SlvParameterInitBool){{"relaxed"
+			,"Solve LP relaxation?",1
+			,"Solve regular problem (FALSE) or LP relaxation of problem (TRUE)."
+		}, FALSE}
+	);
+
+	slv_param_bool(parameters,SP6_NONNEG
+		,(SlvParameterInitBool){{"nonneg"
+			,"Require non-negative?",1
+			,"Solver handles free vars (FALSE) or solver requires that all vars have LB=0, UB=infinity, no FR or MI"
+		}, FALSE}
+	);
+
+	slv_param_int(parameters,SP6_OBJ
+		,(SlvParameterInitInt){{"obj"
+			,"Objective function type",2
+			,"0->solver assumes minimization, do nothing special; 1->solver assumes maximization, swap obj coeff for min problems; 2->solver support SCICONIC style MINIMIZE; 3->solver supports QOMILP style MAX/MIN in names section"
+		}, 0, 0, 3}
+	);
+
+	slv_param_int(parameters,SP6_BINARY
+		,(SlvParameterInitInt){{"binary"
+			,"Binary variable support",2
+			,"0->solver supports binary variables using INTORG; 1->solver supports binary variables with BV option in BOUNDS; 2->no support"
+		}, 2, 0, 2}
+	);
+
+	slv_param_int(parameters,SP6_INTEGER
+		,(SlvParameterInitInt){{"integer"
+			,"Integer variable method",2
+			,"0->solver defines integer vars using INTORG; 1->solver defines integer vars using UI in BOUNDS; 2->no support for integer vars"
+		}, 2, 0, 2}
+	);
+
+
+	slv_param_bool(parameters,SP6_SEMI
+		,(SlvParameterInitBool){{"semi"
+			,"Semi-continuous support?",2
+			,"0->no support; 1->solver supports SCICONIC style semi-continuous vars"
+		}, FALSE}
+	);
+
+	slv_param_bool(parameters,SP6_SOS1
+		,(SlvParameterInitBool){{"sos1"
+			,"SOS1 support?",2
+			,"0->no support; 1->solver supports SOS1, i.e. sum(Xi) = 1"
+		}, FALSE}
+	);
+
+	slv_param_bool(parameters,SP6_SOS2
+		,(SlvParameterInitBool){{"sos2"
+			,"SOS2 support? (ignored)",2
+			,"This parameter currently ignored; no support for type 2 yet. 0->no support; 1->solver supports SOS2, i.e. sum(xi) <=2, with 2 nonzeros being adjacent"
+		}, FALSE}
+	);
+
+	slv_param_bool(parameters,SP6_SOS3
+		,(SlvParameterInitBool){{"sos3"
+			,"SOS3 support?",2
+			,"0->no support; 1->solver supports SOS3, i.e. sum(xi) <= 1"
+		}, FALSE}
+	);
+
+	slv_param_bool(parameters,SP6_BO
+		,(SlvParameterInitBool){{"bo"
+			,"BO current bound support?",3
+			,"0->no support; 1->solver supports QOMILP-style BO cutoff bound in names section. Note: value of bound is set in 'bndval'."
+		}, FALSE}
+	);
+
+	slv_param_bool(parameters,SP6_EPS
+		,(SlvParameterInitBool){{"eps"
+			,"EPS termination criterion support?",4
+			,"0->no support; 1->solver supports QOMILP-style EPS termination criterion. Note: value of bound is set in 'epsval'."
+		}, FALSE}
+	);
+
+
+	slv_param_real(parameters,SP6_BOVAL
+		,(SlvParameterInitReal){{"boval"
+			,"BO cutoff bound value",3
+			,"Value of QOMILP style BO cutoff bound in names section. Ignored if 'bo' is FALSE."
+		}, 0, -1e99, 1.e99}
+	);
+
+	slv_param_real(parameters,SP6_EPSVAL
+		,(SlvParameterInitReal){{"epsval"
+			,"EPS termination criterion value",4
+			,"Value of QOMILP-style EPS termination criterion. Note: Ignored if 'eps' is FALSE."
+		}, 0, -1e99, 1.e99}
+	);
+
+	slv_param_real(parameters,SP6_PINF
+		,(SlvParameterInitReal){{"pinf"
+			,"Positive 'infinity' value",5
+			,"Any upper bound greater than 'pinf' will be set to +infinity"
+		}, 1e30, 0, 1.e99}
+	);
+
+	slv_param_real(parameters,SP6_MINF
+		,(SlvParameterInitReal){{"minf"
+			,"Minus 'infinity' value",5
+			,"Any lower bound greater than 'minf' will be set to -infinity"
+		}, -1e30, -1e99, 0}
+	);
+
+	slv_param_char(parameters,SP6_FILENAME
+		,(SlvParameterInitChar){{"filename"
+			,"Output filename",1
+			,"Name of the output file to be created."
+		}, "outfile.txt"}, (char *[]){
+			"outfile.txt","outfile1.txt","outfile2.txt","outfile3.txt",NULL
+		} /* FIXME how to specify that the user can type this in as free text? */
+	);
+
+	asc_assert(parameters->num_parms==SP6_PARAMS);
+
+	return 1;
+}
+
+
+/* _________________________________________________________________________ */
+
+/*
+ ***  Integrity checks
+ ***  ----------------
+ ***     check_system(sys)
+ **/
+
+#define OK        ((int)813025392)
+#define DESTROYED ((int)103289182)
+static int check_system(highs_system_t sys)
+/**
+ ***  Checks sys for NULL and for integrity.
+ **/
+{
+   if( sys == NULL ) {
+      FPRINTF(stderr,"ERROR:  (slv6) check_system\n");
+      FPRINTF(stderr,"        NULL system handle.\n");
+      return 1;
+   }
+
+   switch( sys->integrity ) {
+   case OK:
+      return 0;
+   case DESTROYED:
+      FPRINTF(stderr,"ERROR:  (slv6) check_system\n");
+      FPRINTF(stderr,"        System was recently destroyed.\n");
+      return 1;
+   default:
+      FPRINTF(stderr,"ERROR:  (slv6) check_system\n");
+      FPRINTF(stderr,"        System reused or never allocated.\n");
+      return 1;
+   }
+}
+
+/* _________________________________________________________________________ */
+
+/*
+ ***  Array/vector operations
+ ***  ----------------------------
+ ***     destroy_array(p)
+ ***     create_array(len,type)
+ ***     zero_array(arr,len,type)
+ ***     nuke_pointers(mps_data_t mps)  - free allocated memory in mps
+ **/
+
+#define destroy_array(p)  \
+   if( (p) != NULL ) ascfree((p))
+#define create_array(len,type)  \
+   ((len) > 0 ? ASC_NEW_ARRAY(type,len) : NULL)
+#define create_zero_array(len,type)  \
+   ((len) > 0 ? ASC_NEW_ARRAY_CLEAR(type,len) : NULL)
+#define zero_array(arr,nelts,type)    \
+   mem_zero_byte_cast((arr),0,(nelts)*sizeof(type))
+/* Zeros an array of nelts objects, each having given type. */
+
+
+static void nuke_pointers(mps_data_t mps) { /* free all allocated memory in mps data structure */
+
+   if (mps.Ac_mtx != NULL) {       /* delete old matrix if the exist */
+       mtx_destroy(mps.Ac_mtx);
+       mps.Ac_mtx = NULL;
+   }
+
+   if (mps.lbrow != NULL) {        /* delete old vector if it exists */
+       destroy_array(mps.lbrow);
+       mps.lbrow = NULL;
+   }
+
+   if (mps.ubrow != NULL) {        /* delete old vector if it exists */
+       destroy_array(mps.ubrow);
+       mps.ubrow = NULL;
+   }
+
+   if (mps.bcol != NULL) {         /* delete old vector if the exist */
+       destroy_array(mps.bcol);
+       mps.bcol = NULL;
+   }
+
+   if (mps.typerow != NULL) {      /* delete old vector if it exists */
+       destroy_array(mps.typerow);
+       mps.typerow = NULL;
+   }
+
+   if (mps.relopcol != NULL) {     /* delete old vector if it exists */
+       destroy_array(mps.relopcol);
+       mps.relopcol = NULL;
+   }
+}
+
+/* _________________________________________________________________________ */
+
+/*
+ ***  General input/output routines
+ ***  -----------------------------
+ ***     fp = MIF(sys)
+ ***     fp = LIF(sys)
+ **/
+
+/*
+ ***  Routines for common filters
+ ***  -----------------
+ ***  highs_free_inc_var_filter -  true for non-fixed incident variables
+ ***  inc_rel_filter      -  true for incident relations
+ **/
+
+/**
+	I've been calling this particular var filter a lot ,
+	so I decided to make it a subroutine.  Returns true if
+	var is not fixed and incident in something.
+*/
+extern boolean highs_free_inc_var_filter(struct var_variable *var){
+      var_filter_t vfilter;
+	   /* Solver lists are already reduced; do not require VAR_INCIDENT flags here. */
+	   vfilter.matchbits = (VAR_FIXED | VAR_ACTIVE);
+	   vfilter.matchvalue = VAR_ACTIVE;
+
+      /*     vfilter.fixed = var_false;*/            /* calc for all non-fixed vars */
+      /* vfilter.incident = var_true;  */        /* incident vars only */
+      /* vfilter.in_block = var_ignore; */
+
+      return var_apply_filter(var,&vfilter);
+}
+
+static boolean inc_rel_filter(struct rel_relation *rel)
+/**
+ ***  Returns true if rel is an incident relation.
+ **/
+{
+   rel_filter_t rfilter;  /* filter for included rels */
+   rfilter.matchbits = (REL_INCLUDED | REL_ACTIVE);
+   rfilter.matchvalue = (REL_INCLUDED| REL_ACTIVE );
+   /*   rfilter.included = rel_true;
+   rfilter.equality = rel_ignore;
+   rfilter.in_block = rel_ignore;
+   rfilter.in_subregion = rel_ignore; */
+
+   return rel_apply_filter(rel,&rfilter);
+}
+
+
+/* _________________________________________________________________________ */
+
+/*
+ ***  Routines to calculate the mps problem representation
+ ***  --------------------
+ ***  var_relaxed - is the variable relaxed or not?
+ ***  calc_c - calculate c vector, coefficients of objective
+        (called by calc_matrix)
+ ***  calc_bounds - convert var bounds to an array of numbers
+ ***  calc_reloplist - convert relation operators <=, >=, = to array of numbers
+ ***  calc_svtlist - create array of numbers containing var types
+ ***  calc_matrix - compute entire matrix representaion of problem
+ **/
+
+
+/**
+ ***  Calculate gradient of the objective function. (or any expression, for that matter)
+ ***  On the linear system we should have, this is the c vector of
+ ***  our problem max/min {cx: Ax<=b}.
+ ***  On nonlinear problems is the linearization of problem at current point
+ **/
+static boolean calc_c(mtx_matrix_t mtx,     /* matrix to store derivs */
+                      int32 org_row,  /* original number of row to store them */
+                      struct rel_relation  *obj)           /* expression to diffs */
+{
+      var_filter_t vfilter;
+      mtx_coord_t coord;
+      real64 *derivs = NULL;
+      int32 *vars = NULL;
+      int32 len, count, i;
+      int32 row;
+      int status;
+      int safe = 0;
+
+      if ((mtx == NULL) || (obj == NULL)) {         /* got a bad pointer */
+          FPRINTF(stderr,"ERROR:  (slv6) calc_c\n");
+          FPRINTF(stderr,"        Routine was passed a NULL pointer!\n");
+          return FALSE;
+      }
+
+      vfilter.matchbits = (VAR_FIXED | VAR_INCIDENT | VAR_ACTIVE);
+      vfilter.matchvalue = (VAR_INCIDENT | VAR_ACTIVE);
+      /*      vfilter.fixed = var_false;
+      vfilter.incident = var_true;
+      vfilter.in_block = var_ignore;    */
+
+      row = mtx_org_to_row(mtx,org_row);       /* convert from original numbering to current */
+      if(row < 0){
+          FPRINTF(stderr,"ERROR:  (slv6) calc_c\n");
+          FPRINTF(stderr,"        Invalid objective row index %d.\n", (int)org_row);
+          return FALSE;
+      }
+
+      len = rel_n_incidences(obj);
+      if(len <= 0){
+          return TRUE;
+      }
+
+      derivs = ASC_NEW_ARRAY_OR_NULL(real64,len);
+      vars = ASC_NEW_ARRAY_OR_NULL(int32,len);
+      if((derivs == NULL) || (vars == NULL)){
+          FPRINTF(stderr,"ERROR:  (slv6) calc_c\n");
+          FPRINTF(stderr,"        Memory allocation failed.\n");
+          if(derivs)ascfree(derivs);
+          if(vars)ascfree(vars);
+          return FALSE;
+      }
+
+      count = 0;
+      status = relman_diff2(obj,&vfilter,derivs,vars,&count,safe);
+      if(status != 0){
+          FPRINTF(stderr,"ERROR:  (slv6) calc_c\n");
+          FPRINTF(stderr,"        Failed to evaluate objective gradient.\n");
+          ascfree(derivs);
+          ascfree(vars);
+          return FALSE;
+      }
+
+      coord.row = org_row;
+      for(i = 0; i < count; ++i){
+          if(vars[i] < 0 || vars[i] >= mtx_order(mtx)){
+              FPRINTF(stderr,"ERROR:  (slv6) calc_c\n");
+              FPRINTF(stderr,"        Objective column index %d out of range.\n", (int)vars[i]);
+              ascfree(derivs);
+              ascfree(vars);
+              return FALSE;
+          }
+          coord.col = vars[i];
+          mtx_fill_org_value(mtx,&coord,derivs[i]);
+      }
+
+      ascfree(derivs);
+      ascfree(vars);
+      return TRUE;
+}
+
+
+/**
+ **  Stores the upper or lower bounds of all non-fixed, incident vars
+ **  in a new array, which is returned by the routine
+ **/
+static real64 *calc_bounds(struct var_variable **vlist, /* variable list to get bounds */
+                                 int32 vused,      /* number of variables in solver list */
+                                 boolean upper)         /* do upper, else lower */
+
+{
+      real64 *tmp_array_origin;  /* temporary storage for our bounds data */
+      int32 col;
+
+      if (vlist == NULL) {         /* got a bad pointer */
+          FPRINTF(stderr,"ERROR:  (slv6) calc_bounds\n");
+          FPRINTF(stderr,"        Routine was passed a NULL variable list pointer!\n");
+          return FALSE;
+      }
+
+      tmp_array_origin = create_zero_array(vused,real64);
+      if (tmp_array_origin == NULL) {
+          FPRINTF(stderr,"ERROR:  (slv6) calc_bounds\n");
+          FPRINTF(stderr,"        Memory allocation failed!\n");
+          return FALSE;
+      }
+
+      for( ; *vlist != NULL ; ++vlist ){
+         col = var_sindex(*vlist);
+         if((col < 0) || (col >= vused)){
+            FPRINTF(stderr,"ERROR:  (slv6) calc_bounds\n");
+            FPRINTF(stderr,"        Variable index %d out of range.\n",(int)col);
+            ascfree(tmp_array_origin);
+            return FALSE;
+         }
+         if (upper) {
+            tmp_array_origin[col] = var_upper_bound(*vlist);
+         }else{
+            tmp_array_origin[col] = var_lower_bound(*vlist);
+         }
+      }
+      return tmp_array_origin;
+}
+
+
+/**
+ ***  This function constructs the a list of relational operators: <=, >=, =
+ ***  from the relations list.  The values for each relational operator
+ ***  corresponds to rel_TOK_less, rel_TOK_equal, and rel_TOK_greater.
+ ***  (Defined in rel.h)
+ ***  Or rel_TOK_nonincident for relations that aren't incident (see slv6.h)
+ ***
+ ***  Note: the rel_less, rel_equal, and rel_greater routines in rel.h don't
+ ***  behave as you'd expect, and should _not_ be used.  Use rel_type instead.
+ **/
+static char *calc_reloplist(struct rel_relation **rlist,
+                            int32    rused)   /* entry for each relation */
+{
+   char *reloplist;
+   int32 row;
+
+   reloplist = create_zero_array(rused,char);  /* default is rel_TOK_nonincident */
+   if (reloplist == NULL) {         /* memory allocation failed */
+          FPRINTF(stderr,"ERROR:  (slv6) calc_reloplist\n");
+          FPRINTF(stderr,"        Memory allocation failed!\n");
+          return NULL;
+   }
+
+   for ( ;*rlist != NULL; rlist++)
+   {
+       row = rel_sindex(*rlist);
+       if((row < 0) || (row >= rused)){
+           FPRINTF(stderr,"ERROR:  (slv6) calc_reloplist\n");
+           FPRINTF(stderr,"        Relation index %d out of range.\n",(int)row);
+           ascfree(reloplist);
+           return NULL;
+       }
+       if (inc_rel_filter(*rlist))   /* is an incident var */
+           switch(rel_relop(*rlist)) {
+               case e_rel_less:
+               case e_rel_lesseq:
+                              reloplist[row] = rel_TOK_less;
+                              break;
+
+               case e_rel_equal:
+                              reloplist[row] = rel_TOK_equal;
+                              break;
+               case e_rel_greater:
+               case e_rel_greatereq:
+                              reloplist[row] = rel_TOK_greater;
+                              break;
+               default:
+                              FPRINTF(stderr,"ERROR:  (slv6) calc_reloplist\n");
+                              FPRINTF(stderr,"        Unknown relation type (not greater, less, or equal)\n");
+                              ascfree(reloplist);
+                              return NULL;
+           }
+       else{
+           reloplist[row] = rel_TOK_nonincident;
+       }
+
+   }
+
+   return reloplist;
+}
+
+/**
+	This function constructs the solver var list from the variable list.
+
+	WARNING:  This routine assumes that a struct var_variable *is an Instance.
+	In the future this is going to change, and this routine will break.
+
+	UPDATE: have made some steps to fixing above wrong assumption -- Feb 2011 JP.
+ **/
+static char *calc_svtlist( struct var_variable **vlist,    /* input, not modified */
+                           int32 vused,        /* number of vars (incident or nonincident, free or fixed) */
+                           int *solver_var_used,     /* number of each type of var are cached  */
+                           int *solver_relaxed_used,
+                           int *solver_int_used,
+                           int *solver_binary_used,
+                           int *solver_semi_used,
+                           int *solver_other_used,
+                           int *solver_fixed){
+	struct TypeDescription *type;              /* type of the current var */
+	struct TypeDescription *solver_var_type;   /* type of the standard types */
+	struct TypeDescription *solver_int_type;
+	struct TypeDescription *solver_binary_type;
+	struct TypeDescription *solver_semi_type;
+
+	char *svtlist;  /* pointer for storage */
+	int32 orgcol;
+
+	/* get the types for variable definitions */
+
+	if( (solver_var_type = FindType(AddSymbol(MPS_VAR_STR))) == NULL ) {
+		FPRINTF(stderr,"ERROR:  (slv6.c) get_solver_var_type\n");
+		FPRINTF(stderr,"        Type solver_var not defined.\n");
+		FPRINTF(stderr,"        MPS will not work.\n");
+		return NULL;
+	}
+	if( (solver_int_type = FindType(AddSymbol(MPS_INT_STR))) == NULL ) {
+		FPRINTF(stderr,"ERROR:  (slv6.c) get_solver_var_type\n");
+		FPRINTF(stderr,"        Type solver_int not defined.\n");
+		FPRINTF(stderr,"        MPS will not work.\n");
+		return NULL;
+	}
+	if( (solver_binary_type = FindType(AddSymbol(MPS_BINARY_STR))) == NULL ) {
+		FPRINTF(stderr,"ERROR:  (slv6.c) get_solver_var_type\n");
+		FPRINTF(stderr,"        Type solver_binary not defined.\n");
+		FPRINTF(stderr,"        MPS will not work.\n");
+		return NULL;
+	}
+	if( (solver_semi_type = FindType(AddSymbol(MPS_SEMI_STR))) == NULL ) {
+		FPRINTF(stderr,"ERROR:  (slv6.c) get_solver_var_type\n");
+		FPRINTF(stderr,"        Type solver_semi not defined.\n");
+		FPRINTF(stderr,"        MPS will not work.\n");
+		return NULL;
+	}
+
+	/* allocate memory and initialize stuff */
+
+	svtlist = create_array(vused,char);  /* see macro */
+	if (svtlist == NULL) {         /* memory allocation failed */
+		  FPRINTF(stderr,"ERROR:  (slv6) calc_svtlist\n");
+		  FPRINTF(stderr,"        Memory allocation failed for solver var type list!\n");
+		  return NULL;
+	}
+
+	*solver_var_used = 0;
+	*solver_relaxed_used = 0;
+	*solver_int_used = 0;
+	*solver_binary_used = 0;
+	*solver_semi_used = 0;
+	*solver_other_used = 0;
+	*solver_fixed = 0;
+	for(orgcol = 0; orgcol < vused; ++orgcol){
+		svtlist[orgcol] = MPS_FIXED;
+	}
+
+	/* loop over all vars */
+
+	for(; *vlist != NULL ; ++vlist )  {
+		orgcol = var_sindex(*vlist);
+		if((orgcol < 0) || (orgcol >= vused)){
+			FPRINTF(stderr,"ERROR:  (slv6) calc_svtlist\n");
+			FPRINTF(stderr,"        Variable index %d out of range.\n",(int)orgcol);
+			ascfree(svtlist);
+			return NULL;
+		}
+		if(highs_free_inc_var_filter(*vlist) ){
+			type = InstanceTypeDesc(var_instance(*vlist));
+
+			if(type == MoreRefined(type,solver_binary_type) ){
+				if (var_relaxed(*vlist)){
+				   svtlist[orgcol] = MPS_RELAXED;
+				   (*solver_relaxed_used)++;
+				}else{
+				   svtlist[orgcol] = MPS_BINARY;
+				   (*solver_binary_used)++;
+				}
+			}else{
+				if (type == MoreRefined(type,solver_int_type) ){
+					if(var_relaxed(*vlist)){
+						svtlist[orgcol] = MPS_RELAXED;
+						(*solver_relaxed_used)++;
+					}else{
+						svtlist[orgcol] = MPS_INT;
+						(*solver_int_used)++;
+					}
+				}else{
+					if (type == MoreRefined(type,solver_semi_type) ){
+						if (var_relaxed(*vlist)){
+							svtlist[orgcol] = MPS_RELAXED;
+							(*solver_relaxed_used)++;
+						}else{
+							svtlist[orgcol] = MPS_SEMI;
+							(*solver_semi_used)++;
+						}
+					}else{
+						if (type == MoreRefined(type,solver_var_type) ){
+							/* either solver var or some refinement */
+							svtlist[orgcol] = MPS_VAR;
+							(*solver_var_used)++;
+						}else{
+							FPRINTF(stderr,"ERROR:  (slv6) determine_svtlist\n");
+							FPRINTF(stderr,"        Unknown solver_var type encountered.\n");
+							/* should never get to here */
+						}
+					}          /* if semi */
+				}          /* if int */
+			}         /* if binary */
+		}else{
+			svtlist[orgcol] = MPS_FIXED;
+			(*solver_fixed)++;
+		}
+	}
+	return svtlist;
+}
+
+static mtx_matrix_t calc_matrix(int32     cap,
+                                int32     rused,
+                                int32     vused,
+                                struct rel_relation  **rlist,
+                                struct rel_relation *obj,
+                                int32     crow,
+                                slv_status_t    *s,
+                                int32     *rank,
+                                real64    **rhs_orig)
+/**
+	@param     cap,          in: capacity of matrix
+	@param    rused,        in: total number of relations used
+	@param    vused,        in: total number of variables used
+	@param rlist,       in: Relation list (NULL terminated)
+	@param obj,          in: objective function
+	@param crow,         in: row to store objective row
+	@param s,          out: s.block.jactime, and s.calc_ok
+	@param rank,       out
+	@oaram rhs_orig   out: rhs array origin
+
+ ***  Creates and calculates a matrix representation of the A matrix, c row,
+ ***  and the RHS or b column (which is stored in rhs_orig).
+ ***  On nonlinear problems is the linearization of problem at current point.
+ ***
+ *** Note: the residual stored in the rhs array is not the real right hand side.
+ ***  The residual returned by the diffs call is just the value of
+ **         (lhs expr) - (rhs expr)
+ ***  we want the residual excluding the current variables.
+ ***  At the moment there isn't a
+ ***  clean way to do this.  It will be calculated in the real_rhs routine.
+ ***  This routine
+ ***  will take for each relation:
+ ***         sum(i, (Jacobian value var[i])*(Variable value var[i])) - rhs[i]
+ ***  which is the real rhs.
+ ***  However, this will _not_ be valid for the nonlinear case.
+ ***  Other than this, the mps file will be the linearization of a nonlinear
+ ***  system at the
+ ***  current point.  If you are adding an MINLP feature,
+ ***  you'll need to come up with a better way.
+ ***
+<pre>
+ ***       MPS matrix strucutre
+ ***                                    v
+ ***       min/max cx:                  u
+ ***       Ax (<= = >=) b               s
+ ***                                    e
+ ***                       1            d
+ ***
+ ***                       |            |
+ ***                       |            |
+ ***                      \ /          \ /
+ ***
+ ***                      +-            -+
+ ***       1          ->  |              |
+ ***                      |              |
+ ***                      |      A       |
+ ***                      |              |
+ ***       rused      ->  |              |
+ ***                      +-            -+
+ ***
+ ***       crow       ->  [      c       ]
+ ***
+ ***
+ ***       rused                 row of last incident relation
+ ***       crow = rused + 1,     row of cost vector
+ ***       vused                 column of last incident variable
+ ***
+ ***       cap = max(vused+1,rused), size of sparse square matrix
+ ***       cap = N ---> row/column 0 to N-1 exist
+</pre>
+*/
+{
+   mtx_matrix_t mtx;      /* main data structure */
+   var_filter_t vfilter;  /* checks for free incident vars in relman_diffs */
+   double time0;          /* time of Jacobian calculation, among other things */
+   struct rel_relation **rp;    /* relation pointer */
+   int32 orgrow;
+   int status;
+
+   if(obj == NULL) {         /* a little preflight checking */
+      FPRINTF(stderr,"ERROR:  (slv6) calc_matrix\n");
+      FPRINTF(stderr,"        System must have an objective!\n");
+      return NULL;
+   }
+
+   time0=tm_cpu_time();           /* start timing */
+   s->calc_ok = TRUE;            /* no errors yet */
+
+   mtx = mtx_create();            /* create 0 order matrix */
+   mtx_set_order(mtx,cap);        /* adjust size of square matrix to size of cap
+                                    (cap set in presolve.) The relman_diffs
+                                     routine returns values in the matrix */
+                                  /* these routines don't return success/fail */
+
+   vfilter.matchbits = (VAR_FIXED | VAR_INCIDENT | VAR_ACTIVE);
+   vfilter.matchvalue = (VAR_INCIDENT | VAR_ACTIVE);
+   /*   vfilter.fixed = var_false;
+   vfilter.incident = var_true;
+   vfilter.in_block = var_ignore; */
+
+   /* want to save column of residuals as they come along from relman_diffs */
+   *rhs_orig = create_zero_array(rused,real64);
+   if(*rhs_orig == NULL) {         /* memory allocation failed */
+      FPRINTF(stderr,"ERROR:  (slv6) calc_matrix\n");
+      FPRINTF(stderr,"        Memory allocation for right hand side failed!\n");
+      return NULL;
+   }
+
+
+  /* note: the rhs array is the residual at the current point, not what we want!
+     see further comments at the start of this routine */
+
+	int safe = 0;
+
+   for( rp = rlist ; *rp != NULL ; ++rp ) {
+      /* fill out A matrix only for used elements */
+      if( inc_rel_filter(*rp) ) {
+         orgrow = rel_sindex(*rp);
+         if((orgrow < 0) || (orgrow >= rused)){
+            s->calc_ok = FALSE;  /* error in diffs ! */
+            FPRINTF(stderr,"ERROR:  (slv6) calc_matrix\n");
+            FPRINTF(stderr,"        Relation index %d out of range.\n",(int)orgrow);
+            destroy_array(*rhs_orig);  /* clean up house, then die */
+            mtx_destroy(mtx);                 /* zap all alocated memory */
+            return NULL;
+         }
+         status = relman_diffs(*rp,&vfilter,mtx,&((*rhs_orig)[orgrow]),safe);
+         if(status != 0) {
+            s->calc_ok = FALSE;  /* error in diffs ! */
+            FPRINTF(stderr,"ERROR:  (slv6) calc_matrix\n");
+            FPRINTF(stderr,"        Error in calculating A matrix.\n");
+            destroy_array(*rhs_orig);  /* clean up house, then die */
+            mtx_destroy(mtx);                 /* zap all alocated memory */
+            return NULL;
+         }
+      }
+   }
+   /* Calculate the rank of the matrix, before we add extra rows/cols */
+   mtx_output_assign(mtx, crow, vused);
+   if(! mtx_output_assigned(mtx)) {  /* output assignment failed */
+      FPRINTF(stderr,"ERROR:  (slv6) calc_matrix\n");
+      FPRINTF(stderr,"        Output assignment to calculate rank of problem failed.\n");
+      mtx_destroy(mtx);                 /* zap all alocated memory */
+      destroy_array(*rhs_orig);  /* clean up house, then die */
+      return NULL;
+   }
+   *rank = mtx_symbolic_rank(mtx);
+
+   if( *rank < 0 ) {
+      FPRINTF(stderr,"ERROR:  (slv6) calc_matrix\n");
+      FPRINTF(stderr,"        Symbolic rank calculation failed, matrix may be bad.\n");
+      return mtx;
+   }
+
+   /* calculate the c vector and save it to the matrix */
+   if( ! calc_c(mtx, crow, obj) ) {
+      s->calc_ok = FALSE;  /* error in diffs ! */
+      FPRINTF(stderr,"ERROR:  (slv6) calc_matrix\n");
+      FPRINTF(stderr,"        Error in calculating objective coefficients.\n");
+      mtx_destroy(mtx);    /* commit suicide */
+      destroy_array(*rhs_orig);  /* clean up house, then die */
+      return NULL;
+   }
+
+   s->block.jactime = tm_cpu_time() - time0;  /* set overall jacobian time */
+
+   return mtx;
+}
+
+
+static void real_rhs(mtx_matrix_t    Ac_mtx,      /* Matrix representation of problem */
+                     char            relopcol[],  /* is it incident? */
+                     struct var_variable  **vlist,      /* Variable list (NULL terminated) */
+                     int32     rused,       /* in: total number of relations used */
+                     int32     vused,       /* in: total number of variables used */
+                     real64    rhs[])       /* out: rhs array origin */
+/**
+ ***  Takes the residuals stored in rhs, and converts them into the actual right
+ ***  hand sides we want.
+ ***
+ ***  Note: the residual stored in the rhs array is not the real right hand side.
+ ***  The residual returned by the diffs call is just the value of
+ **         (lhs expr) - (rhs expr)
+ ***  we want the residual excluding the current variables.  At the moment there isn't a
+ ***  clean way to do this.  It will be calculated in the real_rhs routine.  This routine
+ ***  will take for each relation:
+ ***         sum(i, (Jacobian value var[i])*(Variable value var[i])) - rhs[i]
+ ***  which is the real rhs.  However, this will _not_ be valid for the nonlinear case.
+ ***  Other than this, the mps file will be the linearization of a nonlinear system at the
+ ***  current point.  If you are adding an MINLP feature, you'll need to come up with a better way.
+ ***
+ **/
+{
+   real64 a;        /* value of mtx element */
+   mtx_coord_t  nz;       /* coordinate of row/column in A matrix */
+   mtx_range_t  range;    /* storage for range of A matrix, run down a column */
+   int32  currow;   /* counter for current row */
+   int          orgrow;   /* original row number */
+   int          orgcol;   /* orignal col number */
+   double       rowval;   /* the sum of a[i]*x[i] in the row */
+
+   if(rhs == NULL) {         /* a little preflight checking */
+      FPRINTF(stderr,"ERROR:  (slv6) real_rhs\n");
+      FPRINTF(stderr,"        The routine was passed a NULL rhs pointer!\n");
+      return;
+   }
+
+   for(currow = 0; currow < rused; currow++)      {      /* loop over all rows, is _current_ column number */
+      orgrow = mtx_row_to_org(Ac_mtx, currow);
+      if (relopcol[orgrow] != rel_TOK_nonincident)  {   /* if it is incident row */
+
+ 	   nz.col = mtx_FIRST;    /* first nonzero col */
+	   nz.row = currow;       /* current row */
+           rowval = 0.0;          /* accumulate value here */
+
+           a = mtx_next_in_row(Ac_mtx,&nz,mtx_range(&range,0,vused));
+
+           do  {  orgcol  = mtx_col_to_org(Ac_mtx, nz.col);
+                  rowval += a*var_value(*(vlist+orgcol));
+                  a = mtx_next_in_row(Ac_mtx,&nz,mtx_range(&range,0,vused));
+
+               } while (nz.col != mtx_LAST);
+
+          rhs[orgrow] = rowval - rhs[orgrow];  /* set real value of right hand side */
+
+      }
+  }
+
+}
+
+/* _________________________________________________________________________ */
+
+/**
+ ***  Routines used by presolve
+ ***  --------------------
+ ***  insure_bounds - fix inconsistent bounds
+ ***  update_vlist - add vars to vlist
+ ***  determine_vlist - build new vlist
+ **/
+
+
+static void insure_bounds(FILE *mif,highs_system_t sys, struct var_variable *var)
+/**
+ ***  Insures that the variable value is within its bounds.
+ **/
+{
+   real64 val,low,high;
+
+   low = var_lower_bound(var);
+   high = var_upper_bound(var);
+   val = var_value(var);
+   if( low > high ) {
+      FPRINTF(mif,"Bounds for variable ");
+      slv_print_var_name(mif,sys->slv,var);
+      FPRINTF(mif," are inconsistent [%g,%g].\n",low,high);
+      FPRINTF(mif,"Bounds will be swapped.\n");
+      var_set_upper_bound(var, low);
+      var_set_lower_bound(var, high);
+      low = var_lower_bound(var);
+      high = var_upper_bound(var);
+   }
+
+   if( low > val ) {
+      FPRINTF(mif,"Variable ");
+      slv_print_var_name(mif,sys->slv,var);
+      FPRINTF(mif," was initialized below its lower bound.\n");
+      FPRINTF(mif,"It will be moved to its lower bound.\n");
+      var_set_value(var, low);
+   } else if( val > high ) {
+      FPRINTF(mif,"Variable ");
+      slv_print_var_name(mif,sys->slv,var);
+      FPRINTF(mif," was initialized above its upper bound.\n");
+      FPRINTF(mif,"It will be moved to its upper bound.\n");
+      var_set_value(var, high);
+   }
+}
+
+#ifndef KILL
+
+static struct var_variable **update_vlist(struct var_variable * *vlist, expr_t expr)
+/**
+ ***  Updates vlist, adding variables incident on given expression.  The
+ ***  old list is destroyed and the new list is returned.
+ **/
+{
+   struct var_variable **newlist,**elist;
+   long nelts;
+
+   elist = expr_incidence_list(expr,NULL);
+   if( vlist == NULL ) return(elist);
+   if( (nelts=pl_length(elist)) == 0 ) {
+      ascfree( (POINTER)elist );
+      return(vlist);
+   }
+
+   nelts += pl_length(vlist) + 1;
+   newlist = (struct var_variable **)ascmalloc( sizeof(struct var_variable *) * (int)nelts );
+   pl_merge_0(newlist,vlist,elist);
+   ascfree( (POINTER)vlist );
+   ascfree( (POINTER)elist );
+   return(newlist);
+}
+
+#endif
+
+#ifndef KILL
+
+/**
+	This function constructs the variable list from the relation list.  It
+	is assumed that sys->vlist_user == NULL so that this is necessary.
+
+	@todo FIXME this function seems to be building its own vlist, which we
+	shouldn't have to do using the 'new' Solver API.
+*/
+static void determine_vlist(highs_system_t sys){
+   bnd_boundary_t *bp;
+   struct rel_relation **rp;
+
+   if( pl_length(sys->vlist) > 0 )
+      ascfree( (POINTER)sys->vlist );
+   sys->vlist = NULL;
+   for( bp=sys->blist ; *bp != NULL ; ++bp ) {
+      sys->vlist = update_vlist(sys->vlist,bnd_lhs(*bp));
+      sys->vlist = update_vlist(sys->vlist,bnd_rhs(*bp));
+   }
+   for( rp=sys->rlist ; *rp != NULL ; ++rp ) {
+      sys->vlist = update_vlist(sys->vlist,rel_lhs(*rp));
+      sys->vlist = update_vlist(sys->vlist,rel_rhs(*rp));
+   }
+   if( sys->obj )
+      sys->vlist = update_vlist(sys->vlist,sys->obj);
+
+   if( sys->vlist == NULL )
+      highs_set_var_list(sys,NULL);
+}
+
+#endif
+
+/* _________________________________________________________________________ */
+
+/**
+ ***  External routines used from slv0 without modificiation
+ ***
+ ***  highs_set_var_list(sys,vlist)
+ ***  highs_get_var_list(sys)
+ ***  highs_set_bnd_list(sys,blist)
+ ***  highs_get_bnd_list(sys)
+ ***  highs_set_rel_list(sys,rlist)
+ ***  highs_get_rel_list(sys)
+ ***  highs_set_extrel_list(sys,erlist)
+ ***  highs_get_extrel_list(sys)
+ ***  highs_count_vars(sys,vfilter)
+ ***  highs_count_bnds(sys,bfilter)
+ ***  highs_count_rels(sys,rfilter)
+ ***  highs_set_obj_function(sys,obj)
+ ***  highs_get_obj_function(sys)
+ ***  highs_get_parameters(sys,parameters)
+ ***  highs_set_parameters(sys,parameters)
+ ***  highs_get_status(sys,status)
+ ***  highs_dump_internals(sys,level)
+ **/
+
+
+#if 0
+void highs_set_var_list(highs_system_t sys, struct var_variable **vlist){
+   static struct var_variable *empty_list[] = {NULL};
+   check_system(sys);
+   if( sys->vlist_user == NULL )
+      if( sys->vlist != NULL && pl_length(sys->vlist) > 0 )
+	 ascfree( (POINTER)(sys->vlist) );
+   sys->vlist_user = vlist;
+   sys->vlist = (vlist==NULL ? empty_list : vlist);
+   sys->s.ready_to_solve = FALSE;
+}
+
+struct var_variable **highs_get_var_list(highs_system_t sys){
+   check_system(sys);
+   return( sys->vlist_user );
+}
+
+void highs_set_bnd_list(highs_system_t sys, struct bnd_boundary *blist){
+   static struct bnd_boundary empty_list[] = {};
+   check_system(sys);
+   sys->blist_user = blist;
+   sys->blist = (blist==NULL ? empty_list : blist);
+   sys->s.ready_to_solve = FALSE;
+}
+
+struct bnd_boundary *highs_get_bnd_list(sys)
+highs_system_t sys;
+{
+   check_system(sys);
+   return( sys->blist_user );
+}
+
+void highs_set_rel_list(sys,rlist)
+highs_system_t sys;
+struct rel_relation **rlist;
+{
+   static struct rel_relation *empty_list[] = {NULL};
+   check_system(sys);
+   sys->rlist_user = rlist;
+   sys->rlist = (rlist==NULL ? empty_list : rlist);
+   sys->s.ready_to_solve = FALSE;
+}
+
+struct rel_relation **highs_get_rel_list(sys)
+highs_system_t sys;
+{
+   check_system(sys);
+   return( sys->rlist_user );
+}
+
+void highs_set_extrel_list(sys,erlist)
+highs_system_t sys;
+struct ExtRelCache **erlist;
+{
+   static struct ExtRelCache *empty_list[] = {NULL};
+   check_system(sys);
+   sys->erlist_user = erlist;
+   sys->erlist = (erlist==NULL ? empty_list : erlist);
+   sys->s.ready_to_solve = FALSE;
+}
+
+struct ExtRelCache **highs_get_extrel_list(sys)
+highs_system_t sys;
+{
+   check_system(sys);
+   return( sys->erlist_user );
+}
+
+int highs_count_vars(sys,vfilter)
+highs_system_t sys;
+var_filter_t *vfilter;
+{
+   struct var_variable **vp;
+   int32 count = 0;
+   check_system(sys);
+   for( vp=sys->vlist; *vp != NULL; vp++ )
+      if( var_apply_filter(*vp,vfilter) ) ++count;
+   return( count );
+}
+
+int highs_count_bnds(highs_system_t sys,bnd_filter_t *bfilter){
+	struct bnd_boundary *bp;
+	int32 count = 0;
+	check_system(sys);
+	for( bp=sys->blist; *bp != NULL; bp++ ){
+		if( bnd_apply_filter(*bp,bfilter) ) ++count;
+	}
+	return( count );
+}
+
+int highs_count_rels(highs_system_t sys,rel_filter_t *rfilter){
+   struct rel_relation **rp;
+   int32 count = 0;
+   check_system(sys);
+   for( rp=sys->rlist; *rp != NULL; rp++ )
+      if( rel_apply_filter(*rp,rfilter) ) ++count;
+   return( count );
+}
+
+void highs_set_obj_relation(highs_system_t sys,struct rel_relation *obj){
+   check_system(sys);
+   sys->obj = obj;
+   sys->s.ready_to_solve = FALSE;
+}
+
+struct rel_relation *highs_get_obj_relation(highs_system_t sys){
+   check_system(sys);
+   return(sys->obj);
+}
+
+void highs_dump_internals(highs_system_t sys, int level){
+   check_system(sys);
+   if (level > 0) {
+      FPRINTF(stderr,"ERROR:  (slv6) highs_dump_internals\n");
+      FPRINTF(stderr,"        slv6 does not dump its internals.\n");
+   }
+}
+#endif
+
+void highs_get_parameters(slv_system_t server,slv_parameters_t *parameters){
+	highs_system_t sys;
+	sys = SYS(server);
+	check_system(sys);
+	mem_copy_cast(&(sys->p),parameters,sizeof(slv_parameters_t));
+}
+
+void highs_set_parameters(slv_system_t server, slv_parameters_t *parameters){
+	highs_system_t sys;
+	sys = SYS(server);
+	check_system(sys);
+	if (parameters->whose==highs_solver_number)
+	mem_copy_cast(parameters,&(sys->p),sizeof(slv_parameters_t));
+}
+
+void highs_get_status(slv_system_t server, slv_status_t *status){
+	highs_system_t sys;
+	sys = SYS(server);
+	check_system(sys);
+	mem_copy_cast(&(sys->s),status,sizeof(slv_status_t));
+}
+
+/* _________________________________________________________________________ */
+
+/**
+ ***  External routines with minor modifications
+ ***  -----------------
+ ***  highs_change_basis           just return FALSE & error msg
+ **/
+
+boolean highs_change_basis(highs_system_t sys,int32 var, mtx_range_t *rng){
+/* In the MPS file maker, changing the basis doesn't make any sense.
+   Nor, for that matter, is there a basis in the first place.
+   So I just write out an error message, and return FALSE  */
+
+   FPRINTF(stderr,"ERROR:  (slv6) highs_change_basis\n");
+   FPRINTF(stderr,"        This solver does not support changing the basis.\n");
+
+   return FALSE;
+}
+
+
+/* _________________________________________________________________________ */
+
+/*
+ ***  External routines unique to slv6 (Based on routines from slv0)
+ ***  -----------------
+ ***  highs_create()               added solver specific initialization
+ ***  highs_destroy(sys)           added solver specific dealocation
+ ***  highs_eligible_solver(sys)   see if solver can do the current problem
+ ***  highs_presolve(sys)          set up system and create matrix/vectors
+ ***  highs_solve(sys)             call MPS routines
+ ***  highs_iterate(sys)           just calls highs_solve
+ ***  highs_resolve(sys)           just calls highs_solve
+ **/
+
+
+/**
+	This routine allocates memory and initializes all data structures
+	It should be a good source of comments on the system parameters and
+	status flags used in slv6
+*/
+static SlvClientToken highs_create(slv_system_t server, int32 *statusindex){   /* added mps initialization */
+	highs_system_t sys;
+
+	sys = ASC_NEW_CLEAR(struct highs_system_structure);
+	if(sys==NULL){
+		*statusindex = 1;
+		return sys;
+	}
+
+	/* Bind this solver instance to the current system lists. */
+	sys->slv = server;
+	sys->vlist_user = slv_get_solvers_var_list(server);
+	sys->vlist = sys->vlist_user;
+	sys->blist_user = (struct bnd_boundary *)slv_get_solvers_bnd_list(server);
+	sys->blist = sys->blist_user;
+	sys->rlist_user = slv_get_solvers_rel_list(server);
+	sys->rlist = sys->rlist_user;
+	sys->obj = slv_get_obj_relation(server);
+
+	/***  Initialize system parameters ***/
+
+	sys->p.parms = sys->pa;
+	sys->p.dynamic_parms = 0;
+	highs_get_default_parameters(server,(SlvClientToken)sys,&(sys->p));
+	sys->p.whose = (*statusindex);
+
+	sys->integrity = OK;
+
+#if 0
+	sys->p.output.more_important = stdout;  /* used in MIF macro */
+	sys->p.output.less_important = NULL;    /*   used in LIF macro (which is not used) */
+
+	sys->p.tolerance.pivot = 0.1;           /* these tolerances are never used */
+	sys->p.tolerance.singular = 1e-12;
+	sys->p.tolerance.feasible = 1e-8;
+	sys->p.tolerance.stationary = 1e-8;
+	sys->p.tolerance.termination = 1e-12;
+	sys->p.time_limit = 1500.0;             /* never used */
+	sys->p.iteration_limit = 100;           /* never used */
+	sys->p.partition = FALSE;               /* never used, but don't want partitioning */
+	sys->p.ignore_bounds = FALSE;           /* never used, but must satisfy bounds */
+	sys->p.whose = highs_solver_number;      /* read in highs_set_parameters */
+	sys->p.rho = 1.0;
+	sys->p.sp.iap=&(sys->iarray[0]);        /* all defaults in iarray are 0 */
+	sys->p.sp.rap=&(sys->rarray[0]);        /* all defaults in rarray are 0 */
+	sys->p.sp.cap=&(sys->carray[0]);        /* all defaults in carray are NULL */
+	sys->p.sp.vap=NULL;                     /* not currently used */
+#endif
+
+	/***  Initialize mps data structure ***/
+
+	sys->mps.Ac_mtx = NULL;    /* set all pointers to NULL - will all be set in presolve */
+	sys->mps.lbrow = NULL;     /* all other data in mps structure is 0 */
+	sys->mps.ubrow = NULL;
+	sys->mps.bcol = NULL;
+	sys->mps.typerow = NULL;
+	sys->mps.relopcol = NULL;
+
+
+	/***  Initialize status flags ***/
+
+	sys->s.over_defined               = FALSE;  /* set to (sys->mps.rinc > sys->mps.vinc) in highs_presolve */
+	sys->s.under_defined              = FALSE;  /* set to (sys->mps.rinc < sys->mps.vinc) in highs_presolve */
+	sys->s.struct_singular            = FALSE;  /* set to (sys->mps.rank < sys->mps.rinc) in highs_presolve */
+	sys->s.calc_ok                    = TRUE;   /* set in calc_matrix (FALSE if error occurs with diffs calc) */
+	sys->s.ok                         = TRUE;   /* set to (sys->s.calc_ok && !sys->s.struct_singular) in highs_presolve */
+	sys->s.ready_to_solve             = FALSE;  /* set to (sys->.ok) after highs_presolve,
+		                                       set FALSE after:  highs_set_var_list, highs_set_bnd_list,
+		                                           highs_set_rel_list, highs_set_extrel_list, highs_set_obj_function
+		                                       tested in highs_solve */
+	sys->s.converged                  = FALSE;  /* set FALSE after highs_presolve; set TRUE after highs_solve */
+	sys->s.diverged                   = FALSE;  /* always FALSE, never used */
+	sys->s.inconsistent               = FALSE;  /* always FALSE, never used */
+	sys->s.iteration_limit_exceeded   = FALSE;  /* always FALSE, never used */
+	sys->s.time_limit_exceeded        = FALSE;  /* always FALSE, never used */
+
+	sys->s.block.number_of            = 1;      /* always 1, just have 1 block */
+	sys->s.block.current_block        = 0;      /* always 1, start in first and only block */
+	sys->s.block.current_size         = 0;      /* set to sys->mps.vused in highs_presolve */
+	sys->s.block.previous_total_size  = 0;      /* always 0, never used */
+
+	/* same : */
+	sys->s.block.iteration            = 0;      /* set to 0 after highs_presolve; set to 1 after highs_solve */
+	sys->s.iteration                  = 0;      /* set to 0 after highs_presolve; set to 1 after highs_solve */
+
+	/* same : */
+	sys->s.block.cpu_elapsed          = 0.0;    /* set to time taken by highs_presolve and highs_solve */
+	sys->s.cpu_elapsed                = 0.0;    /* set to time taken by highs_presolve and highs_solve */
+
+	sys->s.block.functime             = 0.0;    /* always 0.0 since no function evaluation, never used */
+	sys->s.block.residual             = 0.0;    /* always 0.0 since not iterating, never used */
+	sys->s.block.jactime              = 0.0;    /* calculated in highs_presolve, time for jacobian eval */
+
+	sys->s.costsize                   = sys->s.block.number_of;  /* just one cost block, which will be set in  */
+
+	sys->s.cost=create_zero_array(sys->s.costsize,struct slv_block_cost);  /* allocate memory */
+
+
+	/* Note: the cost vars are equivalent to other sys->s.* vars
+
+	sys->s.cost->size        = sys->s.block.current_size
+	sys->s.cost->iterations  = sys->s.block.iteration
+	sys->s.cost->jacs        = sys->s.block.iteration
+	sys->s.cost->funcs       = always 0 since no function evals needed
+	sys->s.cost->time        = sys->s.block.cpu_elapsed
+	sys->s.cost->resid       = 0.0  whatever this is ?
+	sys->s.cost->functime    = 0.0  since no function evals needed
+	sys->s.cost->jactime     = sys->s.block.jactime
+
+	*/
+
+	return(sys);
+}
+
+static int highs_destroy(slv_system_t server, SlvClientToken asys){
+	highs_system_t sys;
+	sys = SYS(server);
+	//int i;
+	if(server == NULL || sys==NULL)return 1;
+
+	if(check_system(sys))return 1;
+#if 0
+	highs_set_var_list(sys,(struct var_variable **)NULL);
+	//highs_set_obj_function(sys,NULL);
+	highs_set_bnd_list(sys,NULL);
+	highs_set_rel_list(sys,NULL);
+	highs_set_extrel_list(sys,NULL);
+#endif
+	sys->integrity = DESTROYED;
+	if (sys->s.cost) ascfree(sys->s.cost);  /* deallocate cost array */
+
+	slv_destroy_parms(&(sys->p));
+
+	nuke_pointers(sys->mps);   /* free memory, and set all pointers to NULL */
+	ascfree( (POINTER)sys );
+
+
+	return 0;
+}
+
+
+/**
+	The system must have a relation list and objective before
+	highs_eligible_solver will return true
+ */
+boolean highs_eligible_solver(highs_system_t server){
+	highs_system_t sys;
+	sys = SYS(server);
+
+   struct rel_relation **rp;
+   var_filter_t vfilter;
+
+   check_system(sys);
+   if( sys->rlist == NULL ) {
+      FPRINTF(stderr,"ERROR:  (slv6) highs_eligible_solver\n");
+      FPRINTF(stderr,"        Relation list was never set.\n");
+      return (FALSE);
+   }
+   if( sys->obj == NULL ) {
+      FPRINTF(stderr,"ERROR:  (slv6) highs_eligible_solver\n");
+      FPRINTF(stderr,"        No objective in problem.\n");
+      return (FALSE);
+   }
+
+   /* To Do:  External Relations are currently being ingored.  Is that proper?
+              What if they're nonlinear   */
+
+   vfilter.matchbits = (VAR_FIXED | VAR_INCIDENT | VAR_ACTIVE);
+   vfilter.matchvalue = (VAR_INCIDENT | VAR_ACTIVE);
+   /*
+   vfilter.fixed = var_false;
+   vfilter.incident = var_true;
+   vfilter.in_block = var_ignore;   */
+
+   /*  Check that the system is linear if iarray[SP6_NONLIN] == 0 */
+   if (SLV_PARAM_BOOL(&(sys->p),SP6_NONLIN) == 0){
+      for( rp=sys->rlist ; *rp != NULL ; ++rp )   /* check relations */
+          if(!relman_is_linear(*rp,&vfilter)) {
+            FPRINTF(MIF(sys), "ERROR:  With the current settings, the MPS generator can only\n");
+            FPRINTF(MIF(sys), "        handle linear models. Nonlinearity in constraint:\n");
+            slv_print_rel_name(MIF(sys),sys->slv, *rp);
+            return(FALSE);   /* don't do nonlinearities */
+          }
+      if(!relman_is_linear(sys->obj,&vfilter)){
+          FPRINTF(MIF(sys), "ERROR:  With the current settings, the MPS generator can only\n");
+          FPRINTF(MIF(sys), "        handle linear models. Nonlinearity in objective:\n");
+          slv_print_rel_name(MIF(sys),sys->slv, sys->obj);
+          return(FALSE);   /* don't do nonlinearities */
+      }
+   }
+
+   /*  Note: initially I had this routine check to see if solver could handle
+       binary, integer, semicontinuous, etc.  Now I just convert types automatically.
+       Binary vars become integer vars if a solver can do int but not binary.
+       Semicontinuous vars become regular solver vars, with warnings about the
+       conversion.  If it can't handle integer vars, they are treated as regular
+       solver vars, with warnings.
+
+       These conversions take place in the MPS.c file.*/
+
+   return TRUE;
+}
+
+void highs_presolve(slv_system_t server){
+	highs_system_t sys;
+	sys = SYS(server);
+
+   struct var_variable **vp;
+   struct rel_relation **rp;
+
+   /* Check if necessary pointers are non-NULL */
+   check_system(sys);
+   if( sys->vlist == NULL ) {
+      FPRINTF(stderr,"ERROR:  (slv6) highs_presolve\n");
+      FPRINTF(stderr,"        Variable list was never set.\n");
+      return;
+   }
+   if( sys->blist == NULL ) {
+      FPRINTF(stderr,"ERROR:  (slv6) highs_presolve\n");
+      FPRINTF(stderr,"        Boundary list was never set.\n");
+      return;
+   }
+   if( sys->rlist == NULL ) {
+      FPRINTF(stderr,"ERROR:  (slv6) highs_presolve\n");
+      FPRINTF(stderr,"        Relation list was never set.\n");
+      return;
+   }
+
+   /* time presolve */
+   sys->clock = tm_cpu_time();  /* record start time */
+
+#if 0
+/*  set up vlist, if necessary, and set all vars, rels, and boundary's
+    to being nonincident, set up index scheme */
+
+#ifndef KILL
+   if( sys->vlist_user == NULL ) determine_vlist(sys);
+#else
+   if( sys->vlist_user == NULL ){
+     FPRINTF(stderr,"  function determine_vlist is slv6 is broken.\n");
+     exit(1);
+   }
+#endif
+   sys->mps.cap = 0;
+   for( vp=sys->vlist,cap=0 ; *vp != NULL ; ++vp ) {
+      var_set_sindex(*vp,cap++);
+      var_set_in_block(*vp,FALSE);
+   }
+   sys->mps.cap = cap;
+   for( rp=sys->rlist,cap=0 ; *rp != NULL ; ++rp ) {
+      rel_set_sindex(*rp,cap++);
+      rel_set_in_block(*rp,FALSE);
+      rel_set_satisfied(*rp,FALSE);
+   }
+   sys->mps.cap = MAX(sys->mps.cap,cap+1);   /* allow an extra relation for crow,
+                                                cap = N --> row/col 0 to N-1 exist */
+   for( bp = sys->blist ; *bp != NULL ; ++bp ) {
+      bnd_set_in_block(*bp,FALSE);
+      bnd_set_active(*bp,FALSE);
+   }
+
+    /**
+    ***  Now mark all variables appearing in the objective function,
+    ***  the boundaries and the relations as incident.
+    **/
+
+   /* Mark all variables appearing in the objective function as incident */
+   if( sys->obj ) exprman_decide_incidence_obj(sys->obj);
+
+      /* Set incidence of included vars in included bounds, calc bused, set all bounds inactive */
+   sys->mps.bused = 0;
+   bfilter.included = bnd_true;
+   bfilter.in_block = bnd_ignore;
+   for( bp = sys->blist ; *bp != NULL ; bp++ ) {
+      if( bnd_apply_filter(*bp,&bfilter) ) {
+	  bndman_decide_incidence(*bp);  /* mark incident variables */
+          sys->mps.bused++;
+      }
+   }
+
+   /* Count the incident relations in rused */
+   sys->mps.rused = 0;
+   sys->mps.rinc = 0;
+   for( rp = sys->rlist ; *rp != NULL ; rp++ ) {
+      rel_set_satisfied(*rp,FALSE);
+      if( inc_rel_filter(*rp) ) {
+     	 relman_decide_incidence(*rp);   /* mark incident variables in included rels */
+         sys->mps.rinc++;
+      }
+      sys->mps.rused++;
+   }
+
+#endif
+	  /* Legacy incidence setup above is disabled; compute the core counts here. */
+	   sys->mps.rused = 0;
+	   sys->mps.rinc = 0;
+	   for( rp = sys->rlist ; *rp != NULL ; ++rp ) {
+	      if( inc_rel_filter(*rp) ) {
+	         sys->mps.rinc++;
+	      }
+	      sys->mps.rused++;
+	   }
+
+	      /* compute info for variables */
+	   sys->mps.vused = 0;     /* number starting at 0 */
+	   sys->mps.vinc = 0;
+	   for( vp = sys->vlist ; *vp != NULL ; vp++ ) {
+	      if( highs_free_inc_var_filter(*vp) )
+	          sys->mps.vinc++;
+	      sys->mps.vused++;    /* count up incident, non-fixed vars */
+	   }
+	   if(sys->mps.vinc == 0){
+	      /* Fallback for systems where incident flags are not pre-marked. */
+	      var_filter_t active_free;
+	      active_free.matchbits = (VAR_FIXED | VAR_ACTIVE);
+	      active_free.matchvalue = VAR_ACTIVE;
+	      for( vp = sys->vlist ; *vp != NULL ; ++vp ) {
+	         if( var_apply_filter(*vp,&active_free) ){
+	            sys->mps.vinc++;
+	         }
+	      }
+	   }
+
+	   /* calculate values for other index_mps_t vars */
+	   sys->mps.cap = sys->mps.vused;
+	   if(sys->mps.cap < sys->mps.rused + 1){
+	      sys->mps.cap = sys->mps.rused + 1;
+	   }
+	   sys->mps.crow     = sys->mps.rused;    /* note rused = N means rows 0 to N-1, exist,
+	                                             the next one will be numbered rused */
+	   /* calculate rank later */
+
+	   /* Call highs_elgibile_solver to see if the solver has a chance */
+	   /* If not bail now ... requires the incidence values of prev section be set */
+	   if(! highs_eligible_solver(sys)) {
+	      FPRINTF(stderr,"ERROR:  (slv6) highs_presolve\n");
+	      FPRINTF(stderr,"        Model is not eligible for HiGHS export with current options.\n");
+	      return;
+	   }
+
+   /*  Make sure that at least one incident variable and at least one incident
+       relation exist, else bail */
+   if ((sys->mps.rinc == 0) || (sys->mps.vinc == 0))  {
+      FPRINTF(stderr,"ERROR:  (slv6) highs_presolve\n");
+      FPRINTF(stderr,"        Your model must have at least one incident variable and equation.\n");
+      FPRINTF(stderr,"        Incident variables: %d\n", sys->mps.vinc);
+      FPRINTF(stderr,"        Incident equations: %d\n", sys->mps.rinc);
+      return;
+   }
+
+   /* free memory, and set all pointers to NULL */
+   nuke_pointers(sys->mps);
+
+   /* setup matrix representaion of problem */
+   sys->mps.Ac_mtx = calc_matrix(sys->mps.cap,
+                                 sys->mps.rused,
+                                 sys->mps.vused,
+                                 sys->rlist,
+                                 sys->obj,
+                                 sys->mps.crow,
+                                 &sys->s,        /* how long for the jacobian calcs and any errors */
+                                 &sys->mps.rank,
+                                 &sys->mps.bcol);
+   if( sys->mps.Ac_mtx == NULL ) {
+      FPRINTF(stderr,"ERROR:  (slv6) highs_presolve\n");
+      FPRINTF(stderr,"        Call to calc_matrix failed.\n");
+      nuke_pointers(sys->mps);
+      return;
+   }
+
+   /* get upper bound row */
+   sys->mps.ubrow = calc_bounds(sys->vlist, sys->mps.vused, TRUE);
+   if (sys->mps.ubrow == NULL)  {
+      FPRINTF(stderr,"ERROR:  (slv6) highs_presolve\n");
+      FPRINTF(stderr,"        Error in calculating variable upper bounds.\n");
+      nuke_pointers(sys->mps);
+      return;
+   }
+
+   /* get lower bound row */
+   sys->mps.lbrow = calc_bounds(sys->vlist, sys->mps.vused, FALSE);
+   if (sys->mps.lbrow == NULL)  {
+      FPRINTF(stderr,"ERROR:  (slv6) highs_presolve\n");
+      FPRINTF(stderr,"        Error in calculating variable lower bounds.\n");
+      nuke_pointers(sys->mps);
+      return;
+   }
+
+	/* Call calc_svtlist to allocate array of variable types */
+	sys->mps.typerow = calc_svtlist(sys->vlist,
+	                                sys->mps.vused,
+	                                &sys->mps.solver_var_used,      /* output */
+                                   &sys->mps.solver_relaxed_used,  /* output */
+                                   &sys->mps.solver_int_used,      /* output */
+                                   &sys->mps.solver_binary_used,   /* output */
+                                   &sys->mps.solver_semi_used,     /* output */
+                                   &sys->mps.solver_other_used,    /* output */
+                                   &sys->mps.solver_fixed);        /* output */
+   if(sys->mps.typerow == NULL) {         /* allocation failed */
+      FPRINTF(stderr,"ERROR:  (slv6) highs_presolve\n");
+      FPRINTF(stderr,"        Error in calculating the variable type list!\n");
+      nuke_pointers(sys->mps);
+      return;
+   }
+
+   /* Call calc_reloplist here, to calculate the relational operators >=, <=, = */
+	 sys->mps.relopcol = calc_reloplist(sys->rlist, sys->mps.rused);
+    if(sys->mps.relopcol == NULL) {         /* allocation failed */
+      FPRINTF(stderr,"ERROR:  (slv6) highs_presolve\n");
+      FPRINTF(stderr,"        Error in calculating the relational operators!\n");
+      nuke_pointers(sys->mps);
+      return;
+   }
+
+   /* adjust the rhs vector so it actually contains the rhs */
+   real_rhs(sys->mps.Ac_mtx,      /* Matrix representation of problem */
+            sys->mps.relopcol,    /* is it incident? */
+            sys->vlist,           /* in: Variable list (NULL terminated) */
+            sys->mps.rused,       /* in: total number of relations used */
+            sys->mps.vused,       /* in: total number of variables used */
+            sys->mps.bcol);       /* out: rhs array origin */
+
+
+   /* Call insure_bounds over all vars to make bounds self-consistent */
+   for( vp=sys->vlist; *vp != NULL ; ++vp )
+     insure_bounds(MIF(sys),sys, *vp);
+
+   /* Reset status flags */
+   sys->s.over_defined = (sys->mps.rinc > sys->mps.vinc);
+   sys->s.under_defined = (sys->mps.rinc < sys->mps.vinc);
+   sys->s.struct_singular = (sys->mps.rank < sys->mps.rinc);
+   sys->s.ok = sys->s.calc_ok && !sys->s.struct_singular;
+   sys->s.ready_to_solve = sys->s.ok;
+
+   sys->s.converged = FALSE;      /* changes to true after highs_solve */
+   sys->s.block.current_size = sys->mps.vused;
+   sys->s.cost->size = sys->s.block.current_size;
+
+   sys->s.cpu_elapsed       = (double)(tm_cpu_time() - sys->clock);  /* record times */
+   sys->s.block.cpu_elapsed = sys->s.cpu_elapsed;
+   sys->s.cost->time        = sys->s.cpu_elapsed;
+   sys->s.cost->jactime     = sys->s.block.jactime;  /* from calc_matrix */
+
+   sys->s.block.iteration   = 0;  /* reset iteration "count", changes to 1 after highs_solve */
+   sys->s.iteration         = 0;
+   sys->s.cost->iterations  = 0;
+   sys->s.cost->jacs        = 0;
+
+}
+
+struct highs_problem_data{
+	HighsInt num_col;
+	HighsInt num_row;
+	HighsInt num_nz;
+	HighsInt *a_start;
+	HighsInt *a_index;
+	double *a_value;
+	double *col_cost;
+	double *col_lower;
+	double *col_upper;
+	double *row_lower;
+	double *row_upper;
+	HighsInt *integrality;
+	double *col_value;
+	double *col_dual;
+	double *row_value;
+	double *row_dual;
+};
+
+static void highs_problem_data_free(struct highs_problem_data *p){
+	if(p == NULL)return;
+	if(p->a_start)ascfree(p->a_start);
+	if(p->a_index)ascfree(p->a_index);
+	if(p->a_value)ascfree(p->a_value);
+	if(p->col_cost)ascfree(p->col_cost);
+	if(p->col_lower)ascfree(p->col_lower);
+	if(p->col_upper)ascfree(p->col_upper);
+	if(p->row_lower)ascfree(p->row_lower);
+	if(p->row_upper)ascfree(p->row_upper);
+	if(p->integrality)ascfree(p->integrality);
+	if(p->col_value)ascfree(p->col_value);
+	if(p->col_dual)ascfree(p->col_dual);
+	if(p->row_value)ascfree(p->row_value);
+	if(p->row_dual)ascfree(p->row_dual);
+	memset(p,0,sizeof(*p));
+}
+
+static int highs_build_problem(highs_system_t sys, struct highs_problem_data *p, int *is_mip){
+	int32 rused, vused, orgrow, orgcol, rowcount, nnzmax;
+	int32 currow, curcol;
+	int32 nnz;
+	int *row_map = NULL;
+	int relaxed;
+	double pinf, minf, hinf;
+	mtx_coord_t nz;
+	mtx_range_t range;
+	real64 a;
+	int direction;
+
+	rused = sys->mps.rused;
+	vused = sys->mps.vused;
+	relaxed = SLV_PARAM_BOOL(&(sys->p),SP6_RELAXED);
+	pinf = SLV_PARAM_REAL(&(sys->p),SP6_PINF);
+	minf = SLV_PARAM_REAL(&(sys->p),SP6_MINF);
+	hinf = 1e30;
+	*is_mip = 0;
+
+	memset(p,0,sizeof(*p));
+
+	row_map = ASC_NEW_ARRAY_OR_NULL(int,rused);
+	if(row_map == NULL)return 0;
+	for(orgrow = 0; orgrow < rused; ++orgrow){
+		row_map[orgrow] = -1;
+	}
+
+	rowcount = 0;
+	for(orgrow = 0; orgrow < rused; ++orgrow){
+		if(sys->mps.relopcol[orgrow] != rel_TOK_nonincident){
+			row_map[orgrow] = rowcount++;
+		}
+	}
+
+	nnzmax = 0;
+	for(orgcol = 0; orgcol < vused; ++orgcol){
+		curcol = mtx_org_to_col(sys->mps.Ac_mtx,orgcol);
+		if(curcol < 0)continue;
+		nz.col = curcol;
+		nz.row = mtx_FIRST;
+		a = mtx_next_in_col(sys->mps.Ac_mtx,&nz,mtx_range(&range,0,rused-1));
+		while(nz.row != mtx_LAST){
+			(void)a;
+			++nnzmax;
+			a = mtx_next_in_col(sys->mps.Ac_mtx,&nz,mtx_range(&range,0,rused-1));
+		}
+	}
+
+	p->num_col = (HighsInt)vused;
+	p->num_row = (HighsInt)rowcount;
+	p->num_nz = 0;
+
+	p->a_start = ASC_NEW_ARRAY_OR_NULL(HighsInt,vused+1);
+	p->a_index = ASC_NEW_ARRAY_OR_NULL(HighsInt,MAX(nnzmax,1));
+	p->a_value = ASC_NEW_ARRAY_OR_NULL(double,MAX(nnzmax,1));
+	p->col_cost = ASC_NEW_ARRAY_OR_NULL(double,vused);
+	p->col_lower = ASC_NEW_ARRAY_OR_NULL(double,vused);
+	p->col_upper = ASC_NEW_ARRAY_OR_NULL(double,vused);
+	p->integrality = ASC_NEW_ARRAY_OR_NULL(HighsInt,vused);
+	p->row_lower = ASC_NEW_ARRAY_OR_NULL(double,MAX(rowcount,1));
+	p->row_upper = ASC_NEW_ARRAY_OR_NULL(double,MAX(rowcount,1));
+	p->col_value = ASC_NEW_ARRAY_OR_NULL(double,vused);
+	p->col_dual = ASC_NEW_ARRAY_OR_NULL(double,vused);
+	p->row_value = ASC_NEW_ARRAY_OR_NULL(double,MAX(rowcount,1));
+	p->row_dual = ASC_NEW_ARRAY_OR_NULL(double,MAX(rowcount,1));
+	if(
+		p->a_start == NULL || p->a_index == NULL || p->a_value == NULL
+		|| p->col_cost == NULL || p->col_lower == NULL || p->col_upper == NULL
+		|| p->integrality == NULL || p->row_lower == NULL || p->row_upper == NULL
+		|| p->col_value == NULL || p->col_dual == NULL
+		|| p->row_value == NULL || p->row_dual == NULL
+	){
+		ascfree(row_map);
+		return 0;
+	}
+
+	for(orgcol = 0; orgcol < vused; ++orgcol){
+		p->col_cost[orgcol] = 0.0;
+		p->integrality[orgcol] = kHighsVarTypeContinuous;
+		p->col_lower[orgcol] = (sys->mps.lbrow[orgcol] <= minf) ? -hinf : sys->mps.lbrow[orgcol];
+		p->col_upper[orgcol] = (sys->mps.ubrow[orgcol] >= pinf) ? hinf : sys->mps.ubrow[orgcol];
+		if(!relaxed){
+			switch(sys->mps.typerow[orgcol]){
+				case MPS_INT:
+				case MPS_BINARY:
+					p->integrality[orgcol] = kHighsVarTypeInteger;
+					*is_mip = 1;
+					break;
+				case MPS_SEMI:
+					p->integrality[orgcol] = kHighsVarTypeSemiContinuous;
+					*is_mip = 1;
+					break;
+				default:
+					break;
+			}
+		}
+	}
+
+	for(orgrow = 0; orgrow < rused; ++orgrow){
+		int ridx = row_map[orgrow];
+		if(ridx < 0)continue;
+		switch(sys->mps.relopcol[orgrow]){
+			case rel_TOK_less:
+				p->row_lower[ridx] = -hinf;
+				p->row_upper[ridx] = sys->mps.bcol[orgrow];
+				break;
+			case rel_TOK_greater:
+				p->row_lower[ridx] = sys->mps.bcol[orgrow];
+				p->row_upper[ridx] = hinf;
+				break;
+			case rel_TOK_equal:
+				p->row_lower[ridx] = sys->mps.bcol[orgrow];
+				p->row_upper[ridx] = sys->mps.bcol[orgrow];
+				break;
+			default:
+				p->row_lower[ridx] = -hinf;
+				p->row_upper[ridx] = hinf;
+				break;
+		}
+	}
+
+	currow = mtx_org_to_row(sys->mps.Ac_mtx,sys->mps.crow);
+	if(currow >= 0){
+		nz.row = currow;
+		nz.col = mtx_FIRST;
+		a = mtx_next_in_row(sys->mps.Ac_mtx,&nz,mtx_range(&range,0,vused-1));
+		while(nz.col != mtx_LAST){
+			orgcol = mtx_col_to_org(sys->mps.Ac_mtx,nz.col);
+			if(orgcol >= 0 && orgcol < vused){
+				p->col_cost[orgcol] = a;
+			}
+			a = mtx_next_in_row(sys->mps.Ac_mtx,&nz,mtx_range(&range,0,vused-1));
+		}
+	}
+
+	nnz = 0;
+	for(orgcol = 0; orgcol < vused; ++orgcol){
+		curcol = mtx_org_to_col(sys->mps.Ac_mtx,orgcol);
+		p->a_start[orgcol] = (HighsInt)nnz;
+		if(curcol < 0)continue;
+		nz.col = curcol;
+		nz.row = mtx_FIRST;
+		a = mtx_next_in_col(sys->mps.Ac_mtx,&nz,mtx_range(&range,0,rused-1));
+		while(nz.row != mtx_LAST){
+			orgrow = mtx_row_to_org(sys->mps.Ac_mtx,nz.row);
+			if(orgrow >= 0 && orgrow < rused && row_map[orgrow] >= 0){
+				p->a_index[nnz] = (HighsInt)row_map[orgrow];
+				p->a_value[nnz] = a;
+				++nnz;
+			}
+			a = mtx_next_in_col(sys->mps.Ac_mtx,&nz,mtx_range(&range,0,rused-1));
+		}
+	}
+	p->a_start[vused] = (HighsInt)nnz;
+	p->num_nz = (HighsInt)nnz;
+
+	direction = relman_obj_direction(sys->obj);
+	if(direction == 1){
+		/* nothing to do: HiGHS model sense will be set to maximize */
+	}
+
+	ascfree(row_map);
+	return 1;
+}
+
+void highs_solve(slv_system_t server){
+	highs_system_t sys;
+	void *highs = NULL;
+	struct highs_problem_data p;
+	HighsInt status;
+	HighsInt model_status;
+	HighsInt sense;
+	int is_mip;
+	struct var_variable **vp;
+
+	sys = SYS(server);
+
+	/* make sure none of the LP data pointers are NULL */
+	if ((sys->mps.Ac_mtx == NULL) ||
+		(sys->mps.lbrow == NULL) ||
+		(sys->mps.ubrow == NULL) ||
+		(sys->mps.bcol == NULL) ||
+		(sys->mps.typerow == NULL) ||
+		(sys->mps.relopcol == NULL)
+	){
+		FPRINTF(MIF(sys),"ERROR:  Matrix representation of problem is not available.\n");
+		FPRINTF(MIF(sys),"        Perhaps the presolve routine was not called before highs_solve.\n");
+		return;
+	}
+
+	check_system(sys);
+	if(!sys->s.ready_to_solve){
+		FPRINTF(stderr,"ERROR:  (highs) highs_solve\n");
+		FPRINTF(stderr,"        Not ready to solve.\n");
+		return;
+	}
+
+	sys->clock = tm_cpu_time();
+	is_mip = 0;
+	if(!highs_build_problem(sys,&p,&is_mip)){
+		FPRINTF(stderr,"ERROR:  (highs) highs_solve\n");
+		FPRINTF(stderr,"        Failed constructing sparse LP/MIP arrays.\n");
+		sys->s.converged = FALSE;
+		sys->s.diverged = TRUE;
+		sys->s.ready_to_solve = FALSE;
+		return;
+	}
+
+	highs = Highs_create();
+	if(highs == NULL){
+		FPRINTF(stderr,"ERROR:  (highs) highs_solve\n");
+		FPRINTF(stderr,"        Failed to create HiGHS instance.\n");
+		highs_problem_data_free(&p);
+		sys->s.converged = FALSE;
+		sys->s.diverged = TRUE;
+		sys->s.ready_to_solve = FALSE;
+		return;
+	}
+
+	(void)Highs_setBoolOptionValue(highs,"output_flag",0);
+	sense = (relman_obj_direction(sys->obj) == 1) ? kHighsObjSenseMaximize : kHighsObjSenseMinimize;
+	if(is_mip){
+		status = Highs_passMip(
+			highs,p.num_col,p.num_row,p.num_nz
+			,kHighsMatrixFormatColwise,sense,0.0
+			,p.col_cost,p.col_lower,p.col_upper,p.row_lower,p.row_upper
+			,p.a_start,p.a_index,p.a_value,p.integrality
+		);
+	}else{
+		status = Highs_passLp(
+			highs,p.num_col,p.num_row,p.num_nz
+			,kHighsMatrixFormatColwise,sense,0.0
+			,p.col_cost,p.col_lower,p.col_upper,p.row_lower,p.row_upper
+			,p.a_start,p.a_index,p.a_value
+		);
+	}
+
+	if(status == kHighsStatusError){
+		FPRINTF(stderr,"ERROR:  (highs) highs_solve\n");
+		FPRINTF(stderr,"        Failed passing model to HiGHS.\n");
+		sys->s.converged = FALSE;
+		sys->s.diverged = TRUE;
+		goto done;
+	}
+
+	status = Highs_run(highs);
+	model_status = Highs_getModelStatus(highs);
+	if(status == kHighsStatusError){
+		FPRINTF(stderr,"ERROR:  (highs) highs_solve\n");
+		FPRINTF(stderr,"        HiGHS run failed.\n");
+		sys->s.converged = FALSE;
+		sys->s.diverged = TRUE;
+		goto done;
+	}
+
+	if(
+		Highs_getSolution(highs,p.col_value,p.col_dual,p.row_value,p.row_dual)
+		== kHighsStatusError
+	){
+		FPRINTF(stderr,"ERROR:  (highs) highs_solve\n");
+		FPRINTF(stderr,"        Unable to fetch HiGHS solution.\n");
+		sys->s.converged = FALSE;
+		sys->s.diverged = TRUE;
+		goto done;
+	}
+
+	sys->s.converged = (model_status == kHighsModelStatusOptimal);
+	sys->s.diverged = !sys->s.converged;
+	sys->s.inconsistent = (
+		model_status == kHighsModelStatusInfeasible
+		|| model_status == kHighsModelStatusUnboundedOrInfeasible
+	);
+
+	if(sys->s.converged){
+		for(vp = sys->vlist; *vp != NULL; ++vp){
+			int32 orgcol = var_sindex(*vp);
+			if(orgcol >= 0 && orgcol < sys->mps.vused){
+				var_set_value(*vp,p.col_value[orgcol]);
+			}
+		}
+	}else{
+		FPRINTF(MIF(sys),"WARNING: HiGHS model status is %ld (not optimal).\n",(long)model_status);
+	}
+
+done:
+	sys->s.cpu_elapsed += (double)(tm_cpu_time() - sys->clock);
+	sys->s.block.cpu_elapsed = sys->s.cpu_elapsed;
+	sys->s.cost->time = sys->s.cpu_elapsed;
+	sys->s.ok = sys->s.calc_ok && !sys->s.struct_singular && sys->s.converged;
+	sys->s.ready_to_solve = FALSE;
+	sys->s.block.iteration = 1;
+	sys->s.iteration = 1;
+	sys->s.cost->iterations = 1;
+	sys->s.cost->jacs = 1;
+
+	if(highs)Highs_destroy(highs);
+	highs_problem_data_free(&p);
+}
+
+
+void highs_iterate(slv_system_t server){
+	highs_system_t sys;
+	sys = SYS(server);
+  /*  Writing an MPS file is a one shot deal.  Thus, an interation
+      is equivalent to solving the problem.  So we just call
+      highs_solve   */
+
+   check_system(sys);
+   highs_solve(server);
+}
+
+
+void highs_resolve(slv_system_t server){
+	highs_system_t sys;
+	sys = SYS(server);
+
+  /* This routine is meant to be called when the following parts of
+     the system change:
+       - any parameter except "partition".
+       - variable values.
+       - variable nominal values.
+       - variable bounds.
+     However, if var values or bounds change, we need a new MPS file,
+     so there is no way to use the previous solution.
+     Just call highs_solve, and do it the normal way.
+  */
+
+   check_system(sys);
+	highs_solve(server);
+}
+
+/* Adapters from modern solver API (server + token) to legacy highs callbacks. */
+static int highs_client_destroy(slv_system_t server, SlvClientToken asys){
+	(void)server;
+	return highs_destroy((slv_system_t)asys, asys);
+}
+
+static int highs_client_eligible_solver(slv_system_t server){
+	SlvClientToken asys = slv_get_client_token(server);
+	if(asys == NULL){
+		return 0;
+	}
+	return highs_eligible_solver((highs_system_t)asys) ? 1 : 0;
+}
+
+static void highs_client_get_parameters(slv_system_t server, SlvClientToken asys, slv_parameters_t *parameters){
+	(void)server;
+	highs_get_parameters((slv_system_t)asys, parameters);
+}
+
+static void highs_client_set_parameters(slv_system_t server, SlvClientToken asys, slv_parameters_t *parameters){
+	(void)server;
+	highs_set_parameters((slv_system_t)asys, parameters);
+}
+
+static int highs_client_get_status(slv_system_t server, SlvClientToken asys, slv_status_t *status){
+	(void)server;
+	highs_get_status((slv_system_t)asys, status);
+	return 0;
+}
+
+static int highs_client_solve(slv_system_t server, SlvClientToken asys){
+	(void)server;
+	highs_solve((slv_system_t)asys);
+	return 0;
+}
+
+static int highs_client_presolve(slv_system_t server, SlvClientToken asys){
+	(void)server;
+	highs_presolve((slv_system_t)asys);
+	return 0;
+}
+
+static int highs_client_iterate(slv_system_t server, SlvClientToken asys){
+	(void)server;
+	highs_iterate((slv_system_t)asys);
+	return 0;
+}
+
+static int highs_client_resolve(slv_system_t server, SlvClientToken asys){
+	(void)server;
+	highs_resolve((slv_system_t)asys);
+	return 0;
+}
+
+
+static const SlvFunctionsT highs_client_internals = {
+	highs_solver_number
+	,"HiGHS"
+	,highs_create
+  	,highs_client_destroy
+	,highs_client_eligible_solver
+	,highs_get_default_parameters
+	,highs_client_get_parameters
+	,highs_client_set_parameters
+	,highs_client_get_status
+	,highs_client_solve
+	,highs_client_presolve
+	,highs_client_iterate
+	,highs_client_resolve
+	,NULL
+	,NULL
+	,NULL
+};
+
+
+int highs_register(void){
+	return solver_register(&highs_client_internals);
+}

--- a/solvers/highs/highs.c
+++ b/solvers/highs/highs.c
@@ -1,34 +1,24 @@
 /*
- *  MPS: Ascend MPS file generator
- *  by Craig Schmidt
- *  Created: 2/11/95
- *  Version: $Revision: 1.29 $
- *  Version control file: $RCSfile: slv6.c,v $
- *  Date last modified: $Date: 2000/01/25 02:27:38 $
- *  Last modified by: $Author: ballan $
+ *  HiGHS linear solver interface for ASCEND
+ *  by John Pye
+ *  Created: 14 Feb 2026
  *
- *  This file is part of the SLV solver.
+ *  This file is part of ASCEND
  *
- *  Copyright (C) 1990 Karl Michael Westerberg
- *  Copyright (C) 1993 Joseph Zaher
- *  Copyright (C) 1994 Joseph Zaher, Benjamin Andrew Allan
- *  Copyright (C) 1995 Craig Schmidt
+ *  Copyright (C) 2026 John Pye
  *
- *  The SLV solver is free software; you can redistribute
+ *  ASCEND is free software; you can redistribute
  *  it and/or modify it under the terms of the GNU General Public License as
  *  published by the Free Software Foundation; either version 2 of the
  *  License, or (at your option) any later version.
  *
- *  The SLV solver is distributed in hope that it will be
+ *  ASCEND is distributed in hope that it will be
  *  useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
  *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  *  General Public License for more details.
  *
  *  You should have received a copy of the GNU General Public License
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
- */
-/*  known bugs
- *  still uses pl_ functions and assumes the old slv protocol.
  */
 
 #include "highs.h"
@@ -39,6 +29,7 @@
 #include <ascend/general/tm_time.h>
 #include <ascend/general/list.h>
 #include <ascend/general/dstring.h>
+#include <ascend/utilities/error.h>
 #include <ascend/compiler/module.h>
 #include <ascend/compiler/library.h>
 #include <ascend/compiler/instance_io.h>
@@ -283,8 +274,7 @@ static int check_system(highs_system_t sys)
  **/
 {
    if( sys == NULL ) {
-      FPRINTF(stderr,"ERROR:  (slv6) check_system\n");
-      FPRINTF(stderr,"        NULL system handle.\n");
+      ERROR_REPORTER_HERE(ASC_PROG_ERR,"NULL system handle.");
       return 1;
    }
 
@@ -292,12 +282,10 @@ static int check_system(highs_system_t sys)
    case OK:
       return 0;
    case DESTROYED:
-      FPRINTF(stderr,"ERROR:  (slv6) check_system\n");
-      FPRINTF(stderr,"        System was recently destroyed.\n");
+      ERROR_REPORTER_HERE(ASC_PROG_ERR,"system was recently destroyed.");
       return 1;
    default:
-      FPRINTF(stderr,"ERROR:  (slv6) check_system\n");
-      FPRINTF(stderr,"        System reused or never allocated.\n");
+      ERROR_REPORTER_HERE(ASC_PROG_ERR,"system reused or never allocated.");
       return 1;
    }
 }
@@ -443,8 +431,7 @@ static boolean calc_c(mtx_matrix_t mtx,     /* matrix to store derivs */
       int safe = 0;
 
       if ((mtx == NULL) || (obj == NULL)) {         /* got a bad pointer */
-          FPRINTF(stderr,"ERROR:  (slv6) calc_c\n");
-          FPRINTF(stderr,"        Routine was passed a NULL pointer!\n");
+          ERROR_REPORTER_HERE(ASC_PROG_ERR,"routine was passed a NULL pointer.");
           return FALSE;
       }
 
@@ -456,8 +443,7 @@ static boolean calc_c(mtx_matrix_t mtx,     /* matrix to store derivs */
 
       row = mtx_org_to_row(mtx,org_row);       /* convert from original numbering to current */
       if(row < 0){
-          FPRINTF(stderr,"ERROR:  (slv6) calc_c\n");
-          FPRINTF(stderr,"        Invalid objective row index %d.\n", (int)org_row);
+          ERROR_REPORTER_HERE(ASC_PROG_ERR,"invalid objective row index %d.", (int)org_row);
           return FALSE;
       }
 
@@ -469,8 +455,7 @@ static boolean calc_c(mtx_matrix_t mtx,     /* matrix to store derivs */
       derivs = ASC_NEW_ARRAY_OR_NULL(real64,len);
       vars = ASC_NEW_ARRAY_OR_NULL(int32,len);
       if((derivs == NULL) || (vars == NULL)){
-          FPRINTF(stderr,"ERROR:  (slv6) calc_c\n");
-          FPRINTF(stderr,"        Memory allocation failed.\n");
+          ERROR_REPORTER_HERE(ASC_PROG_ERR,"memory allocation failed.");
           if(derivs)ascfree(derivs);
           if(vars)ascfree(vars);
           return FALSE;
@@ -479,8 +464,7 @@ static boolean calc_c(mtx_matrix_t mtx,     /* matrix to store derivs */
       count = 0;
       status = relman_diff2(obj,&vfilter,derivs,vars,&count,safe);
       if(status != 0){
-          FPRINTF(stderr,"ERROR:  (slv6) calc_c\n");
-          FPRINTF(stderr,"        Failed to evaluate objective gradient.\n");
+          ERROR_REPORTER_HERE(ASC_PROG_ERR,"failed to evaluate objective gradient.");
           ascfree(derivs);
           ascfree(vars);
           return FALSE;
@@ -489,8 +473,7 @@ static boolean calc_c(mtx_matrix_t mtx,     /* matrix to store derivs */
       coord.row = org_row;
       for(i = 0; i < count; ++i){
           if(vars[i] < 0 || vars[i] >= mtx_order(mtx)){
-              FPRINTF(stderr,"ERROR:  (slv6) calc_c\n");
-              FPRINTF(stderr,"        Objective column index %d out of range.\n", (int)vars[i]);
+              ERROR_REPORTER_HERE(ASC_PROG_ERR,"objective column index %d out of range.", (int)vars[i]);
               ascfree(derivs);
               ascfree(vars);
               return FALSE;
@@ -518,23 +501,20 @@ static real64 *calc_bounds(struct var_variable **vlist, /* variable list to get 
       int32 col;
 
       if (vlist == NULL) {         /* got a bad pointer */
-          FPRINTF(stderr,"ERROR:  (slv6) calc_bounds\n");
-          FPRINTF(stderr,"        Routine was passed a NULL variable list pointer!\n");
+          ERROR_REPORTER_HERE(ASC_PROG_ERR,"routine was passed a NULL variable list pointer.");
           return FALSE;
       }
 
       tmp_array_origin = create_zero_array(vused,real64);
       if (tmp_array_origin == NULL) {
-          FPRINTF(stderr,"ERROR:  (slv6) calc_bounds\n");
-          FPRINTF(stderr,"        Memory allocation failed!\n");
+          ERROR_REPORTER_HERE(ASC_PROG_ERR,"memory allocation failed.");
           return FALSE;
       }
 
       for( ; *vlist != NULL ; ++vlist ){
          col = var_sindex(*vlist);
          if((col < 0) || (col >= vused)){
-            FPRINTF(stderr,"ERROR:  (slv6) calc_bounds\n");
-            FPRINTF(stderr,"        Variable index %d out of range.\n",(int)col);
+            ERROR_REPORTER_HERE(ASC_PROG_ERR,"variable index %d out of range.",(int)col);
             ascfree(tmp_array_origin);
             return FALSE;
          }
@@ -566,8 +546,7 @@ static char *calc_reloplist(struct rel_relation **rlist,
 
    reloplist = create_zero_array(rused,char);  /* default is rel_TOK_nonincident */
    if (reloplist == NULL) {         /* memory allocation failed */
-          FPRINTF(stderr,"ERROR:  (slv6) calc_reloplist\n");
-          FPRINTF(stderr,"        Memory allocation failed!\n");
+          ERROR_REPORTER_HERE(ASC_PROG_ERR,"memory allocation failed.");
           return NULL;
    }
 
@@ -575,8 +554,7 @@ static char *calc_reloplist(struct rel_relation **rlist,
    {
        row = rel_sindex(*rlist);
        if((row < 0) || (row >= rused)){
-           FPRINTF(stderr,"ERROR:  (slv6) calc_reloplist\n");
-           FPRINTF(stderr,"        Relation index %d out of range.\n",(int)row);
+           ERROR_REPORTER_HERE(ASC_PROG_ERR,"relation index %d out of range.",(int)row);
            ascfree(reloplist);
            return NULL;
        }
@@ -595,8 +573,7 @@ static char *calc_reloplist(struct rel_relation **rlist,
                               reloplist[row] = rel_TOK_greater;
                               break;
                default:
-                              FPRINTF(stderr,"ERROR:  (slv6) calc_reloplist\n");
-                              FPRINTF(stderr,"        Unknown relation type (not greater, less, or equal)\n");
+                              ERROR_REPORTER_HERE(ASC_PROG_ERR,"unknown relation type.");
                               ascfree(reloplist);
                               return NULL;
            }
@@ -638,27 +615,19 @@ static char *calc_svtlist( struct var_variable **vlist,    /* input, not modifie
 	/* get the types for variable definitions */
 
 	if( (solver_var_type = FindType(AddSymbol(MPS_VAR_STR))) == NULL ) {
-		FPRINTF(stderr,"ERROR:  (slv6.c) get_solver_var_type\n");
-		FPRINTF(stderr,"        Type solver_var not defined.\n");
-		FPRINTF(stderr,"        MPS will not work.\n");
+		ERROR_REPORTER_HERE(ASC_PROG_ERR,"type '%s' not defined; MPS export will not work.", MPS_VAR_STR);
 		return NULL;
 	}
 	if( (solver_int_type = FindType(AddSymbol(MPS_INT_STR))) == NULL ) {
-		FPRINTF(stderr,"ERROR:  (slv6.c) get_solver_var_type\n");
-		FPRINTF(stderr,"        Type solver_int not defined.\n");
-		FPRINTF(stderr,"        MPS will not work.\n");
+		ERROR_REPORTER_HERE(ASC_PROG_ERR,"type '%s' not defined; MPS export will not work.", MPS_INT_STR);
 		return NULL;
 	}
 	if( (solver_binary_type = FindType(AddSymbol(MPS_BINARY_STR))) == NULL ) {
-		FPRINTF(stderr,"ERROR:  (slv6.c) get_solver_var_type\n");
-		FPRINTF(stderr,"        Type solver_binary not defined.\n");
-		FPRINTF(stderr,"        MPS will not work.\n");
+		ERROR_REPORTER_HERE(ASC_PROG_ERR,"type '%s' not defined; MPS export will not work.", MPS_BINARY_STR);
 		return NULL;
 	}
 	if( (solver_semi_type = FindType(AddSymbol(MPS_SEMI_STR))) == NULL ) {
-		FPRINTF(stderr,"ERROR:  (slv6.c) get_solver_var_type\n");
-		FPRINTF(stderr,"        Type solver_semi not defined.\n");
-		FPRINTF(stderr,"        MPS will not work.\n");
+		ERROR_REPORTER_HERE(ASC_PROG_ERR,"type '%s' not defined; MPS export will not work.", MPS_SEMI_STR);
 		return NULL;
 	}
 
@@ -666,8 +635,7 @@ static char *calc_svtlist( struct var_variable **vlist,    /* input, not modifie
 
 	svtlist = create_array(vused,char);  /* see macro */
 	if (svtlist == NULL) {         /* memory allocation failed */
-		  FPRINTF(stderr,"ERROR:  (slv6) calc_svtlist\n");
-		  FPRINTF(stderr,"        Memory allocation failed for solver var type list!\n");
+		  ERROR_REPORTER_HERE(ASC_PROG_ERR,"memory allocation failed for solver var type list.");
 		  return NULL;
 	}
 
@@ -687,8 +655,7 @@ static char *calc_svtlist( struct var_variable **vlist,    /* input, not modifie
 	for(; *vlist != NULL ; ++vlist )  {
 		orgcol = var_sindex(*vlist);
 		if((orgcol < 0) || (orgcol >= vused)){
-			FPRINTF(stderr,"ERROR:  (slv6) calc_svtlist\n");
-			FPRINTF(stderr,"        Variable index %d out of range.\n",(int)orgcol);
+			ERROR_REPORTER_HERE(ASC_PROG_ERR,"variable index %d out of range.",(int)orgcol);
 			ascfree(svtlist);
 			return NULL;
 		}
@@ -727,8 +694,7 @@ static char *calc_svtlist( struct var_variable **vlist,    /* input, not modifie
 							svtlist[orgcol] = MPS_VAR;
 							(*solver_var_used)++;
 						}else{
-							FPRINTF(stderr,"ERROR:  (slv6) determine_svtlist\n");
-							FPRINTF(stderr,"        Unknown solver_var type encountered.\n");
+							ERROR_REPORTER_HERE(ASC_PROG_ERR,"unknown solver_var type encountered.");
 							/* should never get to here */
 						}
 					}          /* if semi */
@@ -822,8 +788,7 @@ static mtx_matrix_t calc_matrix(int32     cap,
    int status;
 
    if(obj == NULL) {         /* a little preflight checking */
-      FPRINTF(stderr,"ERROR:  (slv6) calc_matrix\n");
-      FPRINTF(stderr,"        System must have an objective!\n");
+      ERROR_REPORTER_HERE(ASC_PROG_ERR,"system must have an objective.");
       return NULL;
    }
 
@@ -845,8 +810,7 @@ static mtx_matrix_t calc_matrix(int32     cap,
    /* want to save column of residuals as they come along from relman_diffs */
    *rhs_orig = create_zero_array(rused,real64);
    if(*rhs_orig == NULL) {         /* memory allocation failed */
-      FPRINTF(stderr,"ERROR:  (slv6) calc_matrix\n");
-      FPRINTF(stderr,"        Memory allocation for right hand side failed!\n");
+      ERROR_REPORTER_HERE(ASC_PROG_ERR,"memory allocation for right-hand side failed.");
       return NULL;
    }
 
@@ -862,8 +826,7 @@ static mtx_matrix_t calc_matrix(int32     cap,
          orgrow = rel_sindex(*rp);
          if((orgrow < 0) || (orgrow >= rused)){
             s->calc_ok = FALSE;  /* error in diffs ! */
-            FPRINTF(stderr,"ERROR:  (slv6) calc_matrix\n");
-            FPRINTF(stderr,"        Relation index %d out of range.\n",(int)orgrow);
+            ERROR_REPORTER_HERE(ASC_PROG_ERR,"relation index %d out of range.",(int)orgrow);
             destroy_array(*rhs_orig);  /* clean up house, then die */
             mtx_destroy(mtx);                 /* zap all alocated memory */
             return NULL;
@@ -871,8 +834,7 @@ static mtx_matrix_t calc_matrix(int32     cap,
          status = relman_diffs(*rp,&vfilter,mtx,&((*rhs_orig)[orgrow]),safe);
          if(status != 0) {
             s->calc_ok = FALSE;  /* error in diffs ! */
-            FPRINTF(stderr,"ERROR:  (slv6) calc_matrix\n");
-            FPRINTF(stderr,"        Error in calculating A matrix.\n");
+            ERROR_REPORTER_HERE(ASC_PROG_ERR,"error while calculating A matrix.");
             destroy_array(*rhs_orig);  /* clean up house, then die */
             mtx_destroy(mtx);                 /* zap all alocated memory */
             return NULL;
@@ -882,8 +844,7 @@ static mtx_matrix_t calc_matrix(int32     cap,
    /* Calculate the rank of the matrix, before we add extra rows/cols */
    mtx_output_assign(mtx, crow, vused);
    if(! mtx_output_assigned(mtx)) {  /* output assignment failed */
-      FPRINTF(stderr,"ERROR:  (slv6) calc_matrix\n");
-      FPRINTF(stderr,"        Output assignment to calculate rank of problem failed.\n");
+      ERROR_REPORTER_HERE(ASC_PROG_ERR,"output assignment for rank calculation failed.");
       mtx_destroy(mtx);                 /* zap all alocated memory */
       destroy_array(*rhs_orig);  /* clean up house, then die */
       return NULL;
@@ -891,16 +852,14 @@ static mtx_matrix_t calc_matrix(int32     cap,
    *rank = mtx_symbolic_rank(mtx);
 
    if( *rank < 0 ) {
-      FPRINTF(stderr,"ERROR:  (slv6) calc_matrix\n");
-      FPRINTF(stderr,"        Symbolic rank calculation failed, matrix may be bad.\n");
+      ERROR_REPORTER_HERE(ASC_PROG_ERR,"symbolic rank calculation failed; matrix may be bad.");
       return mtx;
    }
 
    /* calculate the c vector and save it to the matrix */
    if( ! calc_c(mtx, crow, obj) ) {
       s->calc_ok = FALSE;  /* error in diffs ! */
-      FPRINTF(stderr,"ERROR:  (slv6) calc_matrix\n");
-      FPRINTF(stderr,"        Error in calculating objective coefficients.\n");
+      ERROR_REPORTER_HERE(ASC_PROG_ERR,"error calculating objective coefficients.");
       mtx_destroy(mtx);    /* commit suicide */
       destroy_array(*rhs_orig);  /* clean up house, then die */
       return NULL;
@@ -944,8 +903,7 @@ static void real_rhs(mtx_matrix_t    Ac_mtx,      /* Matrix representation of pr
    double       rowval;   /* the sum of a[i]*x[i] in the row */
 
    if(rhs == NULL) {         /* a little preflight checking */
-      FPRINTF(stderr,"ERROR:  (slv6) real_rhs\n");
-      FPRINTF(stderr,"        The routine was passed a NULL rhs pointer!\n");
+      ERROR_REPORTER_HERE(ASC_PROG_ERR,"routine was passed a NULL rhs pointer.");
       return;
    }
 
@@ -988,16 +946,20 @@ static void insure_bounds(FILE *mif,highs_system_t sys, struct var_variable *var
  ***  Insures that the variable value is within its bounds.
  **/
 {
+	char *varname = NULL;
    real64 val,low,high;
+	(void)mif;
 
    low = var_lower_bound(var);
    high = var_upper_bound(var);
    val = var_value(var);
+	varname = var_make_name(sys->slv,var);
+	if(varname == NULL)varname = ASC_STRDUP("<unknown>");
    if( low > high ) {
-      FPRINTF(mif,"Bounds for variable ");
-      slv_print_var_name(mif,sys->slv,var);
-      FPRINTF(mif," are inconsistent [%g,%g].\n",low,high);
-      FPRINTF(mif,"Bounds will be swapped.\n");
+      ERROR_REPORTER_HERE(ASC_PROG_WARNING
+         ,"Bounds for variable '%s' are inconsistent [%g,%g]; swapping."
+         ,varname,low,high
+      );
       var_set_upper_bound(var, low);
       var_set_lower_bound(var, high);
       low = var_lower_bound(var);
@@ -1005,18 +967,19 @@ static void insure_bounds(FILE *mif,highs_system_t sys, struct var_variable *var
    }
 
    if( low > val ) {
-      FPRINTF(mif,"Variable ");
-      slv_print_var_name(mif,sys->slv,var);
-      FPRINTF(mif," was initialized below its lower bound.\n");
-      FPRINTF(mif,"It will be moved to its lower bound.\n");
+      ERROR_REPORTER_HERE(ASC_PROG_WARNING
+         ,"Variable '%s' was initialized below its lower bound; moved to lower bound."
+         ,varname
+      );
       var_set_value(var, low);
    } else if( val > high ) {
-      FPRINTF(mif,"Variable ");
-      slv_print_var_name(mif,sys->slv,var);
-      FPRINTF(mif," was initialized above its upper bound.\n");
-      FPRINTF(mif,"It will be moved to its upper bound.\n");
+      ERROR_REPORTER_HERE(ASC_PROG_WARNING
+         ,"Variable '%s' was initialized above its upper bound; moved to upper bound."
+         ,varname
+      );
       var_set_value(var, high);
    }
+	ASC_FREE(varname);
 }
 
 #ifndef KILL
@@ -1218,8 +1181,7 @@ struct rel_relation *highs_get_obj_relation(highs_system_t sys){
 void highs_dump_internals(highs_system_t sys, int level){
    check_system(sys);
    if (level > 0) {
-      FPRINTF(stderr,"ERROR:  (slv6) highs_dump_internals\n");
-      FPRINTF(stderr,"        slv6 does not dump its internals.\n");
+      ERROR_REPORTER_HERE(ASC_PROG_ERR,"dumping internals is not implemented.");
    }
 }
 #endif
@@ -1259,8 +1221,7 @@ boolean highs_change_basis(highs_system_t sys,int32 var, mtx_range_t *rng){
    Nor, for that matter, is there a basis in the first place.
    So I just write out an error message, and return FALSE  */
 
-   FPRINTF(stderr,"ERROR:  (slv6) highs_change_basis\n");
-   FPRINTF(stderr,"        This solver does not support changing the basis.\n");
+   ERROR_REPORTER_HERE(ASC_PROG_ERR,"changing basis is not supported.");
 
    return FALSE;
 }
@@ -1440,13 +1401,11 @@ boolean highs_eligible_solver(highs_system_t server){
 
    check_system(sys);
    if( sys->rlist == NULL ) {
-      FPRINTF(stderr,"ERROR:  (slv6) highs_eligible_solver\n");
-      FPRINTF(stderr,"        Relation list was never set.\n");
+      ERROR_REPORTER_HERE(ASC_PROG_ERR,"relation list was never set.");
       return (FALSE);
    }
    if( sys->obj == NULL ) {
-      FPRINTF(stderr,"ERROR:  (slv6) highs_eligible_solver\n");
-      FPRINTF(stderr,"        No objective in problem.\n");
+      ERROR_REPORTER_HERE(ASC_PROG_ERR,"no objective in problem.");
       return (FALSE);
    }
 
@@ -1464,15 +1423,21 @@ boolean highs_eligible_solver(highs_system_t server){
    if (SLV_PARAM_BOOL(&(sys->p),SP6_NONLIN) == 0){
       for( rp=sys->rlist ; *rp != NULL ; ++rp )   /* check relations */
           if(!relman_is_linear(*rp,&vfilter)) {
-            FPRINTF(MIF(sys), "ERROR:  With the current settings, the MPS generator can only\n");
-            FPRINTF(MIF(sys), "        handle linear models. Nonlinearity in constraint:\n");
-            slv_print_rel_name(MIF(sys),sys->slv, *rp);
+            char *relname = rel_make_name(sys->slv,*rp);
+            ERROR_REPORTER_HERE(ASC_PROG_ERR
+               ,"With current settings, HiGHS requires linear models; nonlinearity in constraint '%s'."
+               ,(relname ? relname : "<unknown>")
+            );
+            ASC_FREE(relname);
             return(FALSE);   /* don't do nonlinearities */
           }
       if(!relman_is_linear(sys->obj,&vfilter)){
-          FPRINTF(MIF(sys), "ERROR:  With the current settings, the MPS generator can only\n");
-          FPRINTF(MIF(sys), "        handle linear models. Nonlinearity in objective:\n");
-          slv_print_rel_name(MIF(sys),sys->slv, sys->obj);
+          char *relname = rel_make_name(sys->slv,sys->obj);
+          ERROR_REPORTER_HERE(ASC_PROG_ERR
+             ,"With current settings, HiGHS requires linear models; nonlinearity in objective '%s'."
+             ,(relname ? relname : "<unknown>")
+          );
+          ASC_FREE(relname);
           return(FALSE);   /* don't do nonlinearities */
       }
    }
@@ -1499,18 +1464,15 @@ void highs_presolve(slv_system_t server){
    /* Check if necessary pointers are non-NULL */
    check_system(sys);
    if( sys->vlist == NULL ) {
-      FPRINTF(stderr,"ERROR:  (slv6) highs_presolve\n");
-      FPRINTF(stderr,"        Variable list was never set.\n");
+      ERROR_REPORTER_HERE(ASC_PROG_ERR,"variable list was never set.");
       return;
    }
    if( sys->blist == NULL ) {
-      FPRINTF(stderr,"ERROR:  (slv6) highs_presolve\n");
-      FPRINTF(stderr,"        Boundary list was never set.\n");
+      ERROR_REPORTER_HERE(ASC_PROG_ERR,"boundary list was never set.");
       return;
    }
    if( sys->rlist == NULL ) {
-      FPRINTF(stderr,"ERROR:  (slv6) highs_presolve\n");
-      FPRINTF(stderr,"        Relation list was never set.\n");
+      ERROR_REPORTER_HERE(ASC_PROG_ERR,"relation list was never set.");
       return;
    }
 
@@ -1525,7 +1487,7 @@ void highs_presolve(slv_system_t server){
    if( sys->vlist_user == NULL ) determine_vlist(sys);
 #else
    if( sys->vlist_user == NULL ){
-     FPRINTF(stderr,"  function determine_vlist is slv6 is broken.\n");
+     ERROR_REPORTER_HERE(ASC_PROG_ERR,"(highs) determine_vlist is broken.");
      exit(1);
    }
 #endif
@@ -1621,18 +1583,17 @@ void highs_presolve(slv_system_t server){
 	   /* Call highs_elgibile_solver to see if the solver has a chance */
 	   /* If not bail now ... requires the incidence values of prev section be set */
 	   if(! highs_eligible_solver(sys)) {
-	      FPRINTF(stderr,"ERROR:  (slv6) highs_presolve\n");
-	      FPRINTF(stderr,"        Model is not eligible for HiGHS export with current options.\n");
+	      ERROR_REPORTER_HERE(ASC_PROG_ERR,"model is not eligible with current options.");
 	      return;
 	   }
 
    /*  Make sure that at least one incident variable and at least one incident
        relation exist, else bail */
    if ((sys->mps.rinc == 0) || (sys->mps.vinc == 0))  {
-      FPRINTF(stderr,"ERROR:  (slv6) highs_presolve\n");
-      FPRINTF(stderr,"        Your model must have at least one incident variable and equation.\n");
-      FPRINTF(stderr,"        Incident variables: %d\n", sys->mps.vinc);
-      FPRINTF(stderr,"        Incident equations: %d\n", sys->mps.rinc);
+      ERROR_REPORTER_HERE(ASC_PROG_ERR
+         ,"model must have at least one incident variable and equation (incident variables=%d, incident equations=%d)."
+         ,sys->mps.vinc,sys->mps.rinc
+      );
       return;
    }
 
@@ -1650,8 +1611,7 @@ void highs_presolve(slv_system_t server){
                                  &sys->mps.rank,
                                  &sys->mps.bcol);
    if( sys->mps.Ac_mtx == NULL ) {
-      FPRINTF(stderr,"ERROR:  (slv6) highs_presolve\n");
-      FPRINTF(stderr,"        Call to calc_matrix failed.\n");
+      ERROR_REPORTER_HERE(ASC_PROG_ERR,"call to calc_matrix failed.");
       nuke_pointers(sys->mps);
       return;
    }
@@ -1659,8 +1619,7 @@ void highs_presolve(slv_system_t server){
    /* get upper bound row */
    sys->mps.ubrow = calc_bounds(sys->vlist, sys->mps.vused, TRUE);
    if (sys->mps.ubrow == NULL)  {
-      FPRINTF(stderr,"ERROR:  (slv6) highs_presolve\n");
-      FPRINTF(stderr,"        Error in calculating variable upper bounds.\n");
+      ERROR_REPORTER_HERE(ASC_PROG_ERR,"error calculating variable upper bounds.");
       nuke_pointers(sys->mps);
       return;
    }
@@ -1668,8 +1627,7 @@ void highs_presolve(slv_system_t server){
    /* get lower bound row */
    sys->mps.lbrow = calc_bounds(sys->vlist, sys->mps.vused, FALSE);
    if (sys->mps.lbrow == NULL)  {
-      FPRINTF(stderr,"ERROR:  (slv6) highs_presolve\n");
-      FPRINTF(stderr,"        Error in calculating variable lower bounds.\n");
+      ERROR_REPORTER_HERE(ASC_PROG_ERR,"error calculating variable lower bounds.");
       nuke_pointers(sys->mps);
       return;
    }
@@ -1685,8 +1643,7 @@ void highs_presolve(slv_system_t server){
                                    &sys->mps.solver_other_used,    /* output */
                                    &sys->mps.solver_fixed);        /* output */
    if(sys->mps.typerow == NULL) {         /* allocation failed */
-      FPRINTF(stderr,"ERROR:  (slv6) highs_presolve\n");
-      FPRINTF(stderr,"        Error in calculating the variable type list!\n");
+      ERROR_REPORTER_HERE(ASC_PROG_ERR,"error calculating variable type list.");
       nuke_pointers(sys->mps);
       return;
    }
@@ -1694,8 +1651,7 @@ void highs_presolve(slv_system_t server){
    /* Call calc_reloplist here, to calculate the relational operators >=, <=, = */
 	 sys->mps.relopcol = calc_reloplist(sys->rlist, sys->mps.rused);
     if(sys->mps.relopcol == NULL) {         /* allocation failed */
-      FPRINTF(stderr,"ERROR:  (slv6) highs_presolve\n");
-      FPRINTF(stderr,"        Error in calculating the relational operators!\n");
+      ERROR_REPORTER_HERE(ASC_PROG_ERR,"error calculating relational operators.");
       nuke_pointers(sys->mps);
       return;
    }
@@ -1948,6 +1904,10 @@ void highs_solve(slv_system_t server){
 	HighsInt sense;
 	int is_mip;
 	struct var_variable **vp;
+	struct rel_relation **rp;
+	int safeeval;
+	int calc_ok;
+	int all_calc_ok;
 
 	sys = SYS(server);
 
@@ -1959,23 +1919,22 @@ void highs_solve(slv_system_t server){
 		(sys->mps.typerow == NULL) ||
 		(sys->mps.relopcol == NULL)
 	){
-		FPRINTF(MIF(sys),"ERROR:  Matrix representation of problem is not available.\n");
-		FPRINTF(MIF(sys),"        Perhaps the presolve routine was not called before highs_solve.\n");
+		ERROR_REPORTER_HERE(ASC_PROG_ERR
+			,"matrix representation is not available; presolve may not have been called."
+		);
 		return;
 	}
 
 	check_system(sys);
 	if(!sys->s.ready_to_solve){
-		FPRINTF(stderr,"ERROR:  (highs) highs_solve\n");
-		FPRINTF(stderr,"        Not ready to solve.\n");
+		ERROR_REPORTER_HERE(ASC_PROG_ERR,"not ready to solve.");
 		return;
 	}
 
 	sys->clock = tm_cpu_time();
 	is_mip = 0;
 	if(!highs_build_problem(sys,&p,&is_mip)){
-		FPRINTF(stderr,"ERROR:  (highs) highs_solve\n");
-		FPRINTF(stderr,"        Failed constructing sparse LP/MIP arrays.\n");
+		ERROR_REPORTER_HERE(ASC_PROG_ERR,"failed constructing sparse LP/MIP arrays.");
 		sys->s.converged = FALSE;
 		sys->s.diverged = TRUE;
 		sys->s.ready_to_solve = FALSE;
@@ -1984,8 +1943,7 @@ void highs_solve(slv_system_t server){
 
 	highs = Highs_create();
 	if(highs == NULL){
-		FPRINTF(stderr,"ERROR:  (highs) highs_solve\n");
-		FPRINTF(stderr,"        Failed to create HiGHS instance.\n");
+		ERROR_REPORTER_HERE(ASC_PROG_ERR,"failed to create HiGHS instance.");
 		highs_problem_data_free(&p);
 		sys->s.converged = FALSE;
 		sys->s.diverged = TRUE;
@@ -2012,8 +1970,7 @@ void highs_solve(slv_system_t server){
 	}
 
 	if(status == kHighsStatusError){
-		FPRINTF(stderr,"ERROR:  (highs) highs_solve\n");
-		FPRINTF(stderr,"        Failed passing model to HiGHS.\n");
+		ERROR_REPORTER_HERE(ASC_PROG_ERR,"failed passing model to HiGHS.");
 		sys->s.converged = FALSE;
 		sys->s.diverged = TRUE;
 		goto done;
@@ -2022,8 +1979,7 @@ void highs_solve(slv_system_t server){
 	status = Highs_run(highs);
 	model_status = Highs_getModelStatus(highs);
 	if(status == kHighsStatusError){
-		FPRINTF(stderr,"ERROR:  (highs) highs_solve\n");
-		FPRINTF(stderr,"        HiGHS run failed.\n");
+		ERROR_REPORTER_HERE(ASC_PROG_ERR,"HiGHS run failed.");
 		sys->s.converged = FALSE;
 		sys->s.diverged = TRUE;
 		goto done;
@@ -2033,8 +1989,7 @@ void highs_solve(slv_system_t server){
 		Highs_getSolution(highs,p.col_value,p.col_dual,p.row_value,p.row_dual)
 		== kHighsStatusError
 	){
-		FPRINTF(stderr,"ERROR:  (highs) highs_solve\n");
-		FPRINTF(stderr,"        Unable to fetch HiGHS solution.\n");
+		ERROR_REPORTER_HERE(ASC_PROG_ERR,"unable to fetch HiGHS solution.");
 		sys->s.converged = FALSE;
 		sys->s.diverged = TRUE;
 		goto done;
@@ -2054,8 +2009,33 @@ void highs_solve(slv_system_t server){
 				var_set_value(*vp,p.col_value[orgcol]);
 			}
 		}
+
+		safeeval = SLV_PARAM_BOOL(&(sys->p),ASCEND_PARAM_SAFEEVAL);
+		all_calc_ok = 1;
+		calc_ok = 1;
+
+		if(sys->obj != NULL){
+			(void)relman_eval(sys->obj,&calc_ok,safeeval);
+			if(!calc_ok)all_calc_ok = 0;
+		}
+		for(rp = sys->rlist; *rp != NULL; ++rp){
+			if(inc_rel_filter(*rp)){
+				(void)relman_eval(*rp,&calc_ok,safeeval);
+				if(!calc_ok)all_calc_ok = 0;
+			}
+		}
+		sys->s.calc_ok = all_calc_ok;
+
+		if(!all_calc_ok){
+			ERROR_REPORTER_HERE(ASC_PROG_WARNING
+				,"converged but residual/objective refresh failed."
+			);
+		}
 	}else{
-		FPRINTF(MIF(sys),"WARNING: HiGHS model status is %ld (not optimal).\n",(long)model_status);
+		ERROR_REPORTER_HERE(ASC_PROG_WARNING
+			,"model status is %ld (not optimal)."
+			,(long)model_status
+		);
 	}
 
 done:

--- a/solvers/highs/highs.h
+++ b/solvers/highs/highs.h
@@ -1,0 +1,244 @@
+/*
+ *  MPS: Ascend MPS file generator
+ *  by Craig Schmidt
+ *  Created: 2/11/95
+ *  Version: $Revision: 1.13 $
+ *  Version control file: $RCSfile: highs.h,v $
+ *  Date last modified: $Date: 1997/07/18 12:16:23 $
+ *  Last modified by: $Author: mthomas $
+ *
+ *  This file is part of the SLV solver.
+ *
+ *  Copyright (C) 1990 Karl Michael Westerberg
+ *  Copyright (C) 1993 Joseph Zaher
+ *  Copyright (C) 1994 Joseph Zaher, Benjamin Andrew Allan
+ *  Copyright (C) 1995 Craig Schmidt
+ *
+ *  The SLV solver is free software; you can redistribute
+ *  it and/or modify it under the terms of the GNU General Public License as
+ *  published by the Free Software Foundation; either version 2 of the
+ *  License, or (at your option) any later version.
+ *
+ *  The SLV solver is distributed in hope that it will be
+ *  useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** @file
+ *  HiGHS solver registration module.
+ *  <pre>
+ *  Contents:     HiGHS module
+ *
+ *  Authors:      Karl Westerberg
+ *                Joseph Zaher
+ *
+ *  Dates:        06/90 - original version
+ *                04/91 - fine tuned modified marquadt computation,
+ *                        provided minor iterations for step generation
+ *                        within each major iteration of jacobian
+ *                        updates
+ *                06/93 - eliminated pointer sublists being generated
+ *                        at the beginning of each block
+ *                04/94 - extended scope to equality constrained
+ *                        optimization.
+ *
+ *  Description:  This file is created by make_slv_header, so don't
+ *                modify it yourself.  All functions defined in this
+ *                header have identical protocols to the corresponding
+ *                functions in slv.h except that slv_system_t ==>
+ *                highs_system_t and highs_eligible_solver() only takes one
+ *                parameter: the system.  Note also that the select
+ *                solver functions don't exist.
+ *  </pre>
+ *  @todo HiGHS (solver/highs.c) remains legacy code and needs refactoring.
+ *        It currently compiles and is covered by solver tests.
+ *  @todo Restructure solver/slv6 & mps so can remove declarations in
+ *        solver/highs.h out of header.  Currently needed by mps.[ch].
+ */
+
+#ifndef ASC_HIGHS_H
+#define ASC_HIGHS_H
+
+#include <ascend/solver/solver.h>
+#include <ascend/system/slv_client.h>
+
+#include <solvers/makemps/mps_types.h>
+
+typedef struct highs_system_structure *highs_system_t;
+
+int highs_register(void);
+/**<
+ *  Registration function for the ASCEND HiGHS solver.
+ *  This is the function that tells the system about the HiGHS solver.
+ *  Our index is not necessarily going to be 6. That everything here is
+ *  named highs* is just a historical event.
+ *
+ *  @param sff SlvFunctionsT to receive the solver registration info.
+ *  @return Returns non-zero on error (e.g. f == NULL), zero if all is ok.
+ */
+
+/* WOULD LIKE TO REMOVE EVERYTHING BELOW THIS POINT */
+/* THIS DETAIL SHOULD BE IN SOURCE FILE, BUT IS NEEDED BY mps.[ch] */
+/*
+# if 0
+*/
+#define highs_solver_name "HiGHS" /**< Solver's name. don't mess with the caps!*/
+#define highs_solver_number 60   /**< Solver's number */
+
+extern boolean highs_free_inc_var_filter(struct var_variable *var);
+/**<
+ ***  I've been calling this particular var filter a lot ,
+ ***  so I decided to make it a subroutine.  Returns true if
+ ***  var is not fixed and incident in something.
+ **/
+
+#if 0
+extern void highs_set_var_list();
+extern struct var_variable **highs_get_var_list();
+extern void highs_set_bnd_list();
+extern void highs_set_rel_list();
+extern struct rel_relation **highs_get_rel_list();
+extern void highs_set_extrel_list();
+extern struct ExtRelCache **highs_get_extrel_list();
+extern int highs_count_vars();
+extern int highs_count_bnds();
+extern int highs_count_rels();
+extern void highs_set_obj_relation();
+extern struct rel_relation *highs_get_obj_relation();
+extern boolean highs_eligible_solver();
+extern void highs_get_parameters();
+extern void highs_set_parameters();
+extern void highs_get_status();
+//extern linsol_system_t highs_get_linsol_sys();
+extern void highs_dump_internals();
+extern void highs_presolve();
+extern boolean highs_change_basis();
+extern void highs_resolve();
+extern void highs_iterate();
+extern void highs_solve();
+#endif
+
+/*********************************************************************
+    Craig Schmidt 2/15/95
+
+    This section describes the parameters, subparameters,
+    and status flags as used by the solver.
+
+    *** See highs_create() for more specific information   ***
+    *** on parameters and status flags                  ***
+
+    *** Note: the parameters can be changed by the user ***
+    ***       with the highs_set_parameters routine      ***
+
+
+    Use of subparameters in iarray and rarray:
+
+    iarray[SP6_NONLIN]   0->require linear model,
+                         1->solve linearization at current pt
+    iarray[SP6_RELAXED]  0->solve regular problem
+                         1->solve LP relaxation of problem
+    iarray[SP6_NONNEG]   0->solver handles free vars
+                         1->solver requires that all vars have LB=0, UB=infinity, no FR or MI
+    iarray[SP6_OBJ]      0->solver assumes minimization, do nothing special
+                         1->solver assumes maximization, swap obj coeff for min problems
+                         2->solver support SCICONIC style MINIMIZE
+                         3->solver supports QOMILP style MAX/MIN in names section
+    iarray[SP6_BINARY]   0->solver supports binary variables using INTORG
+                         1->solver supports binary variables with BV option in BOUNDS
+                         2->no support
+    iarray[SP6_INTEGER]  0->solver defines integer vars using INTORG
+                         1->solver defines integer vars using UI in BOUNDS
+                         2->no support for integer vars
+    iarray[SP6_SEMI]     0->no support
+                         1->solver supports SCICONIC style semi-continuous vars
+    iarray[SP6_SOS1]     0->no support
+                         1->solver supports SOS1, i.e. sum(Xi)  = 1
+    iarray[SP6_SOS2]     0->no support
+                         1->solver supports SOS2, i.e. sum(xi) <=2, with 2 nonzeros being adjacent
+                         Note: this parameter currently ignored, no support offered for type 2
+    iarray[SP6_SOS3]     0->no support
+                         1->solver supports SOS3, i.e.  sum(xi) <= 1
+    iarray[SP6_BO]       0->no support
+                         1->solver supports QOMILP style BO cutoff bound in names section
+                         Note: value of bound is in rarray[SP6_BNDVAL]
+    iarray[SP6_EPS]      0->no support
+                         1->solver supports QOMILP style EPS termination criterion
+                         Note: value of bound is in rarray[SP6_EPSVAL]
+
+    rarray[SP6_BOVAL]    value of QOMILP style BO cutoff bound in names section
+                         Note: Ignored if iarray[SP6_BO]=0
+    rarray[SP6_EPSVAL]   value of QOMILP style EPS termination criterion
+                         Note: Ignored if iarray[SP6_EPS]=0
+    rarray[SP6_PINF]     any UB >= pinf is set to + infinity
+    rarray[SP6_MINF]     any LB <= minf is set to - infinity
+
+    carray[SP6_FILENAME] pointer to filename to create
+
+*********************************************************************/
+#if 0
+#define highs_IA_SIZE 12
+#define highs_RA_SIZE 4
+#define highs_CA_SIZE 1
+#define highs_VA_SIZE 0
+
+/**< subscripts for ia */
+#define SP6_NONLIN   0
+#define SP6_RELAXED  1
+#define SP6_NONNEG   2
+#define SP6_OBJ      3
+#define SP6_BINARY   4
+#define SP6_INTEGER  5
+#define SP6_SEMI     6
+#define SP6_SOS1     7
+#define SP6_SOS2     8
+#define SP6_SOS3     9
+#define SP6_BO       10
+#define SP6_EPS      11
+
+/**< subscripts for ra */
+#define SP6_BOVAL   0
+#define SP6_EPSVAL  1
+#define SP6_PINF    2
+#define SP6_MINF    3
+
+/**< subscripts for ca */
+#define SP6_FILENAME 0
+#endif
+
+
+enum{
+	/** ASCEND OPTIONS */
+	ASCEND_PARAM_SAFEEVAL = 0
+	/**< integer-valued */
+	, SP6_NONLIN
+	, SP6_RELAXED
+	, SP6_NONNEG
+	, SP6_OBJ
+	, SP6_BINARY
+	, SP6_INTEGER
+	, SP6_SEMI
+	, SP6_SOS1
+	, SP6_SOS2
+	, SP6_SOS3
+	, SP6_BO
+	, SP6_EPS
+	/* real-valued */
+	, SP6_BOVAL
+	, SP6_EPSVAL
+	, SP6_PINF
+	, SP6_MINF
+	/* string-valued */
+	, SP6_FILENAME
+	, SP6_PARAMS
+};
+
+/**< define another token to go with
+   rel_TOK_less, rel_TOK_equal, and rel_TOK_greater,
+   defined in rel.h */
+#define rel_TOK_nonincident 00
+
+#endif  /* ASC_HIGHS_H */

--- a/solvers/makemps/mps.c
+++ b/solvers/makemps/mps.c
@@ -66,7 +66,14 @@
 #include <ascend/utilities/set.h>
 #include <ascend/general/tm_time.h>
 #include <ascend/general/mem.h>
+#include <ascend/utilities/error.h>
 #include <ascend/compiler/instance_io.h>
+
+#ifdef MAKEMPS_DEBUG
+#define MSG(...) CONSOLE_DEBUG(__VA_ARGS__)
+#else
+#define MSG(...) ((void)0)
+#endif
 
 /* _________________________________________________________________________ */
 
@@ -112,9 +119,10 @@ static FILE *open_write(const char *filename)
   if (filename == NULL) filename = "\0";  /* shouldn't pass null to fopen */
   f = fopen(filename, "w");
   if( f == NULL ) {
-	 FPRINTF(stderr,"ERROR:  (MPS) open_write\n");
-	 FPRINTF(stderr,"        Unable to open %s. Error:%s\n",
-	         filename, strerror(errno));
+	 ERROR_REPORTER_HERE(ASC_PROG_ERR
+	 	,"(MPS) open_write: unable to open '%s' (%s)"
+	 	,filename, strerror(errno)
+	 );
   }
 
   return f;
@@ -133,8 +141,10 @@ static boolean close_file(FILE *f)
   s = fclose(f);
   if (s == EOF)
   {
-  	 FPRINTF(stderr,"ERROR:  (MPS) open_write\n");
-             perror("        Unable to close file");
+  	 ERROR_REPORTER_HERE(ASC_PROG_ERR
+	 	,"(MPS) close_file: unable to close file (%s)"
+	 	,strerror(errno)
+	 );
      return FALSE;
   }
   else
@@ -284,8 +294,9 @@ extern boolean write_name_map(const char *name,        /* filename for output */
   //int i;
 
   if ((vlist == NULL) || (name == NULL)) {  /* got a bad pointer */
-          FPRINTF(stderr,"ERROR:  (MPS) write_name_map\n");
-          FPRINTF(stderr,"        Routine was passed a NULL pointer!\n");
+          ERROR_REPORTER_HERE(ASC_PROG_ERR
+          	,"(MPS) write_name_map: routine was passed a NULL pointer"
+          );
           return FALSE;
   }
 
@@ -383,8 +394,9 @@ static void do_name(FILE *out,             /* file */
                FPRINTF(out," MIN\n");          /* optimization direction */
                break;
 
-      default: FPRINTF(stderr,"ERROR:  (MPS) do_name\n");
-               FPRINTF(stderr,"        Unknown option for objective!\n");
+      default: ERROR_REPORTER_HERE(ASC_PROG_ERR
+                   ,"(MPS) do_name: unknown option for objective"
+               );
   }
 
   if (bo == 1)
@@ -414,8 +426,9 @@ static void do_rows(FILE *out,             /* file */
                                     break;
           case rel_TOK_nonincident: break;
 
-          default: FPRINTF(stderr,"ERROR:  (MPS) do_rows\n");
-                   FPRINTF(stderr,"        Unknown value for relational operators!\n");
+          default: ERROR_REPORTER_HERE(ASC_PROG_ERR
+                      ,"(MPS) do_rows: unknown value for relational operators"
+                   );
       }
 
    FPRINTF(out," N  R%07d\n", rused);     /* objective row */
@@ -462,26 +475,32 @@ static void upgrade_vars(FILE *out,             /* file */
                typerow[orgcol] = MPS_INT;
           }
 	  else if ((typerow[orgcol] == MPS_INT) && (dointeger == 2) && (dobinary != 2))  {
-	       FPRINTF(stderr,"WARNING: Variable C%07d was treated as a %s instead of a %s.\n", orgcol, MPS_BINARY_STR, MPS_INT_STR);
-	       FPRINTF(stderr,"         The selected MILP solver does not support %s.\n", MPS_INT_STR);
-	       FPRINTF(stderr,"         Upper bound was set to 1.0.\n");
+	       ERROR_REPORTER_HERE(ASC_PROG_WARNING
+	       	,"Variable C%07d treated as %s instead of %s; selected MILP solver does not support %s. Upper bound set to 1.0."
+	       	,orgcol, MPS_BINARY_STR, MPS_INT_STR, MPS_INT_STR
+	       );
                typerow[orgcol] = MPS_BINARY;
                ubrow[orgcol] = 1.0;   /* note: changed bound */
           }
 	  else if ((typerow[orgcol] == MPS_SEMI) && (dosemi == 0))  {   /* semi not supported */
-	       FPRINTF(stderr,"WARNING: Variable C%07d was converted from a %s to a %s.\n", orgcol, MPS_SEMI_STR, MPS_VAR_STR);
-	       FPRINTF(stderr,"         The selected MILP solver does not support %s.\n", orgcol, MPS_SEMI_STR);
-	       FPRINTF(stderr,"         The solution found may not be correct for your model.\n");
+	       ERROR_REPORTER_HERE(ASC_PROG_WARNING
+	       	,"Variable C%07d converted from %s to %s; selected MILP solver does not support %s. The solution may not be correct for this model."
+	       	,orgcol, MPS_SEMI_STR, MPS_VAR_STR, MPS_SEMI_STR
+	       );
                typerow[orgcol] = MPS_VAR;
           }
 	  else if ((typerow[orgcol] == MPS_BINARY) && (dointeger == 2) && (dobinary ==2))  {  /* neither is supported */
-	       FPRINTF(stderr,"WARNING: Variable C%07d was treated as a %s instead of a %s.\n", orgcol, MPS_VAR_STR, MPS_BINARY_STR);
-	       FPRINTF(stderr,"         The selected MILP solver only supports %s.\n", MPS_VAR_STR);
+	       ERROR_REPORTER_HERE(ASC_PROG_WARNING
+	       	,"Variable C%07d treated as %s instead of %s; selected MILP solver only supports %s."
+	       	,orgcol, MPS_VAR_STR, MPS_BINARY_STR, MPS_VAR_STR
+	       );
                typerow[orgcol] = MPS_VAR;
           }
 	  else if ((typerow[orgcol] == MPS_INT) && (dointeger == 2) && (dobinary == 2))  {  /* neither is supported */
-	       FPRINTF(stderr,"WARNING: Variable C%07d was treated as a %s instead of a %s.\n", orgcol, MPS_VAR_STR, MPS_INT_STR);
-	       FPRINTF(stderr,"         The selected MILP solver only supports %s.\n", MPS_VAR_STR);
+	       ERROR_REPORTER_HERE(ASC_PROG_WARNING
+	       	,"Variable C%07d treated as %s instead of %s; selected MILP solver only supports %s."
+	       	,orgcol, MPS_VAR_STR, MPS_INT_STR, MPS_VAR_STR
+	       );
                typerow[orgcol] = MPS_VAR;
           }
        }
@@ -572,21 +591,21 @@ void scan_SOS(mtx_matrix_t Ac_mtx,     /* Matrix representation of problem */
 
                    value = mtx_next_in_row(Ac_mtx,&nz,mtx_range(&range,0,vused));
                    if  ((nz.col != mtx_FIRST) && (nz.col != mtx_LAST)) {
-                	 if ( nz.col < current_col)  {
+                         if ( nz.col < current_col)  {
                         	   isSOS = FALSE;  /* overlaps prev SOS */
-                        	   FPRINTF(stderr, "nz.col, current_col, mtx_FIRST: %d  %d  %d\n", nz.col, current_col, mtx_FIRST);
+                        	   MSG("nz.col, current_col, mtx_FIRST: %d %d %d", nz.col, current_col, mtx_FIRST);
                          }
                 	 if ((typerow[mtx_col_to_org(Ac_mtx, nz.col)] != MPS_BINARY) &&
                 	     ( typerow[mtx_col_to_org(Ac_mtx, nz.col)] != MPS_INT)) {
                                isSOS = FALSE;  /* var is wrong type */
-                               FPRINTF(stderr, "typerow: %d\n", typerow[mtx_col_to_org(Ac_mtx, nz.col)]);
+                               MSG("typerow: %d", typerow[mtx_col_to_org(Ac_mtx, nz.col)]);
                 	 }
                    }
 
                } while ( (value == 1.0) && (nz.row != mtx_LAST) && isSOS );
 
                if (nz.col != mtx_LAST) isSOS = FALSE;  /* only true if terminated due to mxt_LAST */
-               FPRINTF(stderr, "isSOS,nz.col:%d, %d\n", isSOS,nz.col);
+               MSG("isSOS, nz.col: %d, %d", isSOS,nz.col);
 
          }
          else
@@ -594,7 +613,7 @@ void scan_SOS(mtx_matrix_t Ac_mtx,     /* Matrix representation of problem */
 
          if (isSOS)  /* reorder columns so all line up in first cols */
          {
-             FPRINTF(stderr, "current_row, not_row:%d, %d\n", current_row, not_row);
+             MSG("current_row, not_row: %d, %d", current_row, not_row);
              /* Is a SOS, so rearrange columns so all the vars in the equation
                 are from current_col on.  Also advance current_row by one. */
 
@@ -816,8 +835,9 @@ extern boolean write_MPS(const char *name,                /* filename for output
   real64 boval, epsval, pinf, minf;
 
   if ((name == NULL) || (parms == NULL)) {  /* got a bad pointer */
-          FPRINTF(stderr,"ERROR:  (MPS) write_MPS\n");
-          FPRINTF(stderr,"        Routine was passed a NULL pointer!\n");
+          ERROR_REPORTER_HERE(ASC_PROG_ERR
+          	,"(MPS) write_MPS: routine was passed a NULL pointer"
+          );
           return FALSE;
   }
 
@@ -873,8 +893,9 @@ extern boolean write_MPS(const char *name,                /* filename for output
      }
 
   if (SLV_PARAM_BOOL(parms,SP6_SOS2) == 1)  {    /* don't support SOS2 yet */
-       FPRINTF(stderr,"WARNING:  (MPS) write_MPS\n");
-       FPRINTF(stderr,"          SOS2 are not currently supported in ASCEND!\n");
+       ERROR_REPORTER_HERE(ASC_PROG_WARNING
+       	,"(MPS) write_MPS: SOS2 is not currently supported in ASCEND"
+       );
   }
 
   do_columns(out,                    /* file */

--- a/solvers/makemps/mps.c
+++ b/solvers/makemps/mps.c
@@ -87,7 +87,7 @@ static void stamp(FILE *outfile, boolean newstamp, boolean dostamp, boolean dost
  ***  if newstamp is true
  **/
 {
-   static char stampstr[26];
+   static char stampstr[27];
    static unsigned long stamptime;
    time_t now;
 
@@ -95,7 +95,7 @@ static void stamp(FILE *outfile, boolean newstamp, boolean dostamp, boolean dost
 
    if (newstamp) {  /* generate new stamp */
       stamptime  = (unsigned long) clock();
-      sprintf(&stampstr[0], "%-26s", ctime(&now));
+      snprintf(&stampstr[0], sizeof(stampstr), "%-26s", ctime(&now));
    }
 
    if (dostamp) FPRINTF(outfile,"%-8x", stamptime);  /* only 8 chars for stamp in MPS, so show hex */
@@ -705,7 +705,7 @@ void do_bounds(FILE *out,              /* file */
                real64 lbrow[],   /* array of data */
                real64 ubrow[],   /* array of data */
                char typerow[],         /* array of data */
-               int32 rused,      /* size of arrays */
+               int32 vused,      /* size of arrays */
                int nonneg,             /* allow nonneg vars (no FR or MI) ? */
                int binary_flag,        /* allow BV vars ? */
                int integer_flag,       /* allow UI vars ? */
@@ -750,8 +750,11 @@ void do_bounds(FILE *out,              /* file */
 
    FPRINTF(out,"BOUNDS\n");                             /* section header */
 
-   for(i = 0; i < rused; i++)                          /* loop over all rows */
+   for(i = 0; i < vused; i++)                          /* loop over all columns */
    {
+     if(typerow[i] == MPS_FIXED){
+         continue;
+     }
      if ((typerow[i] == MPS_BINARY) && (binary_flag == 1))   /* do BV */
               FPRINTF(out," BV B%07d  C%07d\n",i,i);
      else if ((typerow[i] == MPS_INT) && (integer_flag == 1))  /* do UI */
@@ -802,51 +805,66 @@ void do_bounds(FILE *out,              /* file */
 
 extern boolean write_MPS(const char *name,                /* filename for output */
 	mps_data_t mps,                  /* the main chunk of data for the problem */
-	struct slv_parameter *parms
+	slv_parameters_t *parms
 ){
-#if 0
   FILE *out;
   int32 sosvar;   /* number of variables used in SOS's */
   int32 sosrel;   /* number of relations defining SOS's */
- // int i;                /* temporary counter */
+  int obj, bo, eps;
+  int relaxed, dointeger, dobinary, dosemi;
+  int nonneg;
+  real64 boval, epsval, pinf, minf;
 
-  if (name == NULL) {  /* got a bad pointer */
+  if ((name == NULL) || (parms == NULL)) {  /* got a bad pointer */
           FPRINTF(stderr,"ERROR:  (MPS) write_MPS\n");
           FPRINTF(stderr,"        Routine was passed a NULL pointer!\n");
           return FALSE;
   }
+
+  obj = SLV_PARAM_INT(parms,SP6_OBJ);
+  bo = SLV_PARAM_BOOL(parms,SP6_BO);
+  eps = SLV_PARAM_BOOL(parms,SP6_EPS);
+  boval = SLV_PARAM_REAL(parms,SP6_BOVAL);
+  epsval = SLV_PARAM_REAL(parms,SP6_EPSVAL);
+  relaxed = SLV_PARAM_BOOL(parms,SP6_RELAXED);
+  dointeger = SLV_PARAM_INT(parms,SP6_INTEGER);
+  dobinary = SLV_PARAM_INT(parms,SP6_BINARY);
+  dosemi = SLV_PARAM_BOOL(parms,SP6_SEMI);
+  nonneg = SLV_PARAM_BOOL(parms,SP6_NONNEG);
+  pinf = SLV_PARAM_REAL(parms,SP6_PINF);
+  minf = SLV_PARAM_REAL(parms,SP6_MINF);
 
   out = open_write(name);
   if (out == NULL) return FALSE;
 
   /* create header */
   do_name(out,                 /* file */
-          iarray[SP6_OBJ],     /* how does it know to max/min */
-          iarray[SP6_BO],      /* QOMILP style cutoff */
-          iarray[SP6_EPS],     /* QOMILP style termination criteria */
-          rarray[SP6_BOVAL],   /* value of cutoff */
-          rarray[SP6_EPSVAL]); /* value of termination criteria */
+          obj,                 /* how does it know to max/min */
+          bo,                  /* QOMILP style cutoff */
+          eps,                 /* QOMILP style termination criteria */
+          boval,               /* value of cutoff */
+          epsval);             /* value of termination criteria */
 
   do_rows(out,            /* file */
           mps.relopcol,   /* need type of constraint <=, >=, = */
-          mps.rinc);      /* number of incident relations */
+          mps.rused);     /* number of relations */
 
   upgrade_vars(out,                  /* file */
                mps.typerow,          /* array of variable type data */
                mps.ubrow,            /* change ub on int -> bin conversion */
                mps.vused,            /* number of vars */
-               iarray[SP6_RELAXED],  /* should the relaxed problem be solved */
-               iarray[SP6_INTEGER],  /* supports integer vars */
-               iarray[SP6_BINARY],   /* supports binary vars */
-               iarray[SP6_SEMI]);    /* supports semi-continuous vars */
+               relaxed,              /* should the relaxed problem be solved */
+               dointeger,            /* supports integer vars */
+               dobinary,             /* supports binary vars */
+               dosemi);              /* supports semi-continuous vars */
 
-  if ((iarray[SP6_SOS1] == 1) || (iarray[SP6_SOS3] == 1))  /* look for SOS's, reorder matrix */
+  if ((SLV_PARAM_BOOL(parms,SP6_SOS1) == 1) || (SLV_PARAM_BOOL(parms,SP6_SOS3) == 1))  /* look for SOS's, reorder matrix */
      scan_SOS(mps.Ac_mtx,     /* Matrix representation of problem */
               mps.relopcol,   /* array of relational operator data */
               mps.bcol,       /* array of RHS data */
               mps.typerow,    /* array of variable type data */
-              mps.rinc,       /* size of incident relations */
-              mps.vinc,       /* number of vars */
+              mps.rused,      /* size of relations */
+              mps.vused,      /* number of vars */
               &sosvar,        /* output: number of variables used in SOS's */
               &sosrel);       /* output: number of relations defining SOS's */
      else {
@@ -854,7 +872,7 @@ extern boolean write_MPS(const char *name,                /* filename for output
               sosrel = 0;
      }
 
-  if (iarray[SP6_SOS2] == 1)  {    /* don't support SOS2 yet */
+  if (SLV_PARAM_BOOL(parms,SP6_SOS2) == 1)  {    /* don't support SOS2 yet */
        FPRINTF(stderr,"WARNING:  (MPS) write_MPS\n");
        FPRINTF(stderr,"          SOS2 are not currently supported in ASCEND!\n");
   }
@@ -866,33 +884,28 @@ extern boolean write_MPS(const char *name,                /* filename for output
              mps.vused,         /* number of vars */
              sosvar,            /* number of variables used in SOS's */
              sosrel,            /* number of SOS's */
-             iarray[SP6_INTEGER],    /* supports integer vars */
-             iarray[SP6_BINARY]);    /* supports binary vars */
+             dointeger,              /* supports integer vars */
+             dobinary);              /* supports binary vars */
 
   do_rhs(out,                 /* file */
          mps.bcol,
          mps.relopcol,
-         mps.rinc,
-         mps.vinc);
+         mps.rused,
+         mps.vused);
 
   do_bounds(out,                   /* file */
             mps.lbrow,        /* array of data */
             mps.ubrow,        /* array of data */
             mps.typerow,      /* array of data */
-            mps.rused,        /* size of arrays */
-            iarray[SP6_NONNEG],    /* allow nonneg vars (no FR or MI) ? */
-            iarray[SP6_BINARY],    /* allow BV vars ? */
-            iarray[SP6_INTEGER],   /* allow UI vars ? */
-            iarray[SP6_SEMI],      /* allow SC vars ? */
-            rarray[SP6_PINF],      /* any UB>=pinf is set to + infinity */
-            rarray[SP6_MINF]);     /* any LB<=minf is set to - infinity */
+            mps.vused,        /* size of arrays */
+            nonneg,           /* allow nonneg vars (no FR or MI) ? */
+            dobinary,         /* allow BV vars ? */
+            dointeger,        /* allow UI vars ? */
+            dosemi,           /* allow SC vars ? */
+            pinf,             /* any UB>=pinf is set to + infinity */
+            minf);            /* any LB<=minf is set to - infinity */
 
   FPRINTF(out, "ENDATA\n");  /* finish up the file */
 
   return close_file(out);
-#else
-  return 0;
-#endif
 }
-
-

--- a/solvers/makemps/mps.c
+++ b/solvers/makemps/mps.c
@@ -160,7 +160,7 @@ static void print_col_element(FILE *out,
  ***  want a newline if the last call was in the middle of a line
  **/
 {
-   static int32 oldvar;
+   static int32 oldvar = -1;
    static int         onetwo;  /* is it the first or second value on the line (ONE or TWO) */
 
    /* set up state */

--- a/solvers/makemps/mps.h
+++ b/solvers/makemps/mps.h
@@ -52,13 +52,11 @@ extern boolean write_name_map(const char *name,
  *
  *  @param name   File name to receive the output.
  *  @param mps    The main chunk of data for the problem.
- *  @param iarray Integer subparameters, array of size slv6_IA_SIZE.
- *  @param rarray Real subparameters, array of size slv6_RA_SIZE.
+ *  @param parms  Solver parameter set.
  *  @return Returns zero on success, non-zero if an error occurred.
  */
 extern boolean write_MPS(const char *name,
                          mps_data_t mps,
-                         struct slv_parameter *parms);
+                         slv_parameters_t *parms);
 
 #endif  /* ASC_MPS_H */
-

--- a/solvers/makemps/slv6.c
+++ b/solvers/makemps/slv6.c
@@ -40,6 +40,7 @@
 #include <ascend/general/tm_time.h>
 #include <ascend/general/list.h>
 #include <ascend/general/dstring.h>
+#include <ascend/utilities/error.h>
 #include <ascend/compiler/module.h>
 #include <ascend/compiler/library.h>
 #include <ascend/compiler/instance_io.h>
@@ -1009,16 +1010,20 @@ static void insure_bounds(FILE *mif,slv6_system_t sys, struct var_variable *var)
  ***  Insures that the variable value is within its bounds.
  **/
 {
+	char *varname = NULL;
    real64 val,low,high;
+	(void)mif;
 
    low = var_lower_bound(var);
    high = var_upper_bound(var);
    val = var_value(var);
+	varname = var_make_name(sys->slv,var);
+	if(varname == NULL)varname = ASC_STRDUP("<unknown>");
    if( low > high ) {
-      FPRINTF(mif,"Bounds for variable ");
-      slv_print_var_name(mif,sys->slv,var);
-      FPRINTF(mif," are inconsistent [%g,%g].\n",low,high);
-      FPRINTF(mif,"Bounds will be swapped.\n");
+      ERROR_REPORTER_HERE(ASC_PROG_WARNING
+         ,"Bounds for variable '%s' are inconsistent [%g,%g]; swapping."
+         ,varname,low,high
+      );
       var_set_upper_bound(var, low);
       var_set_lower_bound(var, high);
       low = var_lower_bound(var);
@@ -1026,18 +1031,19 @@ static void insure_bounds(FILE *mif,slv6_system_t sys, struct var_variable *var)
    }
 
    if( low > val ) {
-      FPRINTF(mif,"Variable ");
-      slv_print_var_name(mif,sys->slv,var);
-      FPRINTF(mif," was initialized below its lower bound.\n");
-      FPRINTF(mif,"It will be moved to its lower bound.\n");
+      ERROR_REPORTER_HERE(ASC_PROG_WARNING
+         ,"Variable '%s' was initialized below its lower bound; moved to lower bound."
+         ,varname
+      );
       var_set_value(var, low);
    } else if( val > high ) {
-      FPRINTF(mif,"Variable ");
-      slv_print_var_name(mif,sys->slv,var);
-      FPRINTF(mif," was initialized above its upper bound.\n");
-      FPRINTF(mif,"It will be moved to its upper bound.\n");
+      ERROR_REPORTER_HERE(ASC_PROG_WARNING
+         ,"Variable '%s' was initialized above its upper bound; moved to upper bound."
+         ,varname
+      );
       var_set_value(var, high);
    }
+	ASC_FREE(varname);
 }
 
 #ifndef KILL
@@ -1485,15 +1491,21 @@ boolean slv6_eligible_solver(slv6_system_t server){
    if (SLV_PARAM_BOOL(&(sys->p),SP6_NONLIN) == 0){
       for( rp=sys->rlist ; *rp != NULL ; ++rp )   /* check relations */
           if(!relman_is_linear(*rp,&vfilter)) {
-            FPRINTF(MIF(sys), "ERROR:  With the current settings, the MPS generator can only\n");
-            FPRINTF(MIF(sys), "        handle linear models. Nonlinearity in constraint:\n");
-            slv_print_rel_name(MIF(sys),sys->slv, *rp);
+            char *relname = rel_make_name(sys->slv,*rp);
+            ERROR_REPORTER_HERE(ASC_PROG_ERR
+               ,"With current settings, MakeMPS requires linear models; nonlinearity in constraint '%s'."
+               ,(relname ? relname : "<unknown>")
+            );
+            ASC_FREE(relname);
             return(FALSE);   /* don't do nonlinearities */
           }
       if(!relman_is_linear(sys->obj,&vfilter)){
-          FPRINTF(MIF(sys), "ERROR:  With the current settings, the MPS generator can only\n");
-          FPRINTF(MIF(sys), "        handle linear models. Nonlinearity in objective:\n");
-          slv_print_rel_name(MIF(sys),sys->slv, sys->obj);
+          char *relname = rel_make_name(sys->slv,sys->obj);
+          ERROR_REPORTER_HERE(ASC_PROG_ERR
+             ,"With current settings, MakeMPS requires linear models; nonlinearity in objective '%s'."
+             ,(relname ? relname : "<unknown>")
+          );
+          ASC_FREE(relname);
           return(FALSE);   /* don't do nonlinearities */
       }
    }

--- a/solvers/makemps/slv6.c
+++ b/solvers/makemps/slv6.c
@@ -61,6 +61,8 @@
 
 #define SYS(s) ((slv6_system_t)(s))
 
+ASC_DLLSPEC SolverRegisterFn makemps_register;
+
 struct slv6_system_structure {
 
    /**
@@ -210,7 +212,7 @@ static int slv6_get_default_parameters(slv_system_t server, SlvClientToken asys
 		}, FALSE}
 	);
 
-	slv_param_bool(parameters,SP6_BO
+	slv_param_bool(parameters,SP6_EPS
 		,(SlvParameterInitBool){{"eps"
 			,"EPS termination criterion support?",4
 			,"0->no support; 1->solver supports QOMILP-style EPS termination criterion. Note: value of bound is set in 'epsval'."
@@ -399,8 +401,9 @@ static FILE *get_output_file(FILE *fp){
 */
 extern boolean free_inc_var_filter(struct var_variable *var){
       var_filter_t vfilter;
-      vfilter.matchbits = (VAR_FIXED | VAR_INCIDENT | VAR_ACTIVE);
-      vfilter.matchvalue = (VAR_INCIDENT | VAR_ACTIVE);
+	   /* Solver lists are already reduced; do not require VAR_INCIDENT flags here. */
+	   vfilter.matchbits = (VAR_FIXED | VAR_ACTIVE);
+	   vfilter.matchvalue = VAR_ACTIVE;
 
       /*     vfilter.fixed = var_false;*/            /* calc for all non-fixed vars */
       /* vfilter.incident = var_true;  */        /* incident vars only */
@@ -452,7 +455,13 @@ static boolean calc_c(mtx_matrix_t mtx,     /* matrix to store derivs */
                       struct rel_relation  *obj)           /* expression to diffs */
 {
       var_filter_t vfilter;
-	  int32 row;
+      mtx_coord_t coord;
+      real64 *derivs = NULL;
+      int32 *vars = NULL;
+      int32 len, count, i;
+      int32 row;
+      int status;
+      int safe = 0;
 
       if ((mtx == NULL) || (obj == NULL)) {         /* got a bad pointer */
           FPRINTF(stderr,"ERROR:  (slv6) calc_c\n");
@@ -467,15 +476,53 @@ static boolean calc_c(mtx_matrix_t mtx,     /* matrix to store derivs */
       vfilter.in_block = var_ignore;    */
 
       row = mtx_org_to_row(mtx,org_row);       /* convert from original numbering to current */
+      if(row < 0){
+          FPRINTF(stderr,"ERROR:  (slv6) calc_c\n");
+          FPRINTF(stderr,"        Invalid objective row index %d.\n", (int)org_row);
+          return FALSE;
+      }
 
-#ifndef KILL
-      exprman_diffs(obj, &vfilter, row, mtx);  /* find the deriviative, sets calc_ok as result */
-#else
-     FPRINTF(stderr,"  function calc_c is slv6 is broken.\n");
-     FPRINTF(stderr," It calls exprman_diffs with wrong number of args.\n");
-     exit(1);
-#endif
-      return calc_ok;                          /* did things work out ?, calc_ok in calc.h */
+      len = rel_n_incidences(obj);
+      if(len <= 0){
+          return TRUE;
+      }
+
+      derivs = ASC_NEW_ARRAY_OR_NULL(real64,len);
+      vars = ASC_NEW_ARRAY_OR_NULL(int32,len);
+      if((derivs == NULL) || (vars == NULL)){
+          FPRINTF(stderr,"ERROR:  (slv6) calc_c\n");
+          FPRINTF(stderr,"        Memory allocation failed.\n");
+          if(derivs)ascfree(derivs);
+          if(vars)ascfree(vars);
+          return FALSE;
+      }
+
+      count = 0;
+      status = relman_diff2(obj,&vfilter,derivs,vars,&count,safe);
+      if(status != 0){
+          FPRINTF(stderr,"ERROR:  (slv6) calc_c\n");
+          FPRINTF(stderr,"        Failed to evaluate objective gradient.\n");
+          ascfree(derivs);
+          ascfree(vars);
+          return FALSE;
+      }
+
+      coord.row = org_row;
+      for(i = 0; i < count; ++i){
+          if(vars[i] < 0 || vars[i] >= mtx_order(mtx)){
+              FPRINTF(stderr,"ERROR:  (slv6) calc_c\n");
+              FPRINTF(stderr,"        Objective column index %d out of range.\n", (int)vars[i]);
+              ascfree(derivs);
+              ascfree(vars);
+              return FALSE;
+          }
+          coord.col = vars[i];
+          mtx_fill_org_value(mtx,&coord,derivs[i]);
+      }
+
+      ascfree(derivs);
+      ascfree(vars);
+      return TRUE;
 }
 
 
@@ -484,11 +531,12 @@ static boolean calc_c(mtx_matrix_t mtx,     /* matrix to store derivs */
  **  in a new array, which is returned by the routine
  **/
 static real64 *calc_bounds(struct var_variable **vlist, /* variable list to get bounds */
-                                 int32 vinc,      /* number of incident variables */
+                                 int32 vused,      /* number of variables in solver list */
                                  boolean upper)         /* do upper, else lower */
 
 {
-      real64 *tmp,*tmp_array_origin;  /* temporary storage for our bounds data */
+      real64 *tmp_array_origin;  /* temporary storage for our bounds data */
+      int32 col;
 
       if (vlist == NULL) {         /* got a bad pointer */
           FPRINTF(stderr,"ERROR:  (slv6) calc_bounds\n");
@@ -496,19 +544,26 @@ static real64 *calc_bounds(struct var_variable **vlist, /* variable list to get 
           return FALSE;
       }
 
-      tmp_array_origin = create_array(vinc,real64);
+      tmp_array_origin = create_zero_array(vused,real64);
       if (tmp_array_origin == NULL) {
           FPRINTF(stderr,"ERROR:  (slv6) calc_bounds\n");
           FPRINTF(stderr,"        Memory allocation failed!\n");
           return FALSE;
       }
 
-      tmp = tmp_array_origin;
       for( ; *vlist != NULL ; ++vlist ){
-        if( free_inc_var_filter(*vlist) ){
-           if (upper) { *tmp=var_upper_bound(*vlist); tmp++; }
-           else   { *tmp=var_lower_bound(*vlist); tmp++; }
-        }
+         col = var_sindex(*vlist);
+         if((col < 0) || (col >= vused)){
+            FPRINTF(stderr,"ERROR:  (slv6) calc_bounds\n");
+            FPRINTF(stderr,"        Variable index %d out of range.\n",(int)col);
+            ascfree(tmp_array_origin);
+            return FALSE;
+         }
+         if (upper) {
+            tmp_array_origin[col] = var_upper_bound(*vlist);
+         }else{
+            tmp_array_origin[col] = var_lower_bound(*vlist);
+         }
       }
       return tmp_array_origin;
 }
@@ -528,41 +583,47 @@ static char *calc_reloplist(struct rel_relation **rlist,
                             int32    rused)   /* entry for each relation */
 {
    char *reloplist;
-   char *tmp;                  /* pointer for storage */
+   int32 row;
 
-   reloplist = create_array(rused,char);  /* see macro, over all incident relations */
+   reloplist = create_zero_array(rused,char);  /* default is rel_TOK_nonincident */
    if (reloplist == NULL) {         /* memory allocation failed */
           FPRINTF(stderr,"ERROR:  (slv6) calc_reloplist\n");
           FPRINTF(stderr,"        Memory allocation failed!\n");
           return NULL;
    }
 
-   tmp = reloplist;
    for ( ;*rlist != NULL; rlist++)
    {
+       row = rel_sindex(*rlist);
+       if((row < 0) || (row >= rused)){
+           FPRINTF(stderr,"ERROR:  (slv6) calc_reloplist\n");
+           FPRINTF(stderr,"        Relation index %d out of range.\n",(int)row);
+           ascfree(reloplist);
+           return NULL;
+       }
        if (inc_rel_filter(*rlist))   /* is an incident var */
            switch(rel_relop(*rlist)) {
                case e_rel_less:
                case e_rel_lesseq:
-                              *tmp = rel_TOK_less;
+                              reloplist[row] = rel_TOK_less;
                               break;
 
                case e_rel_equal:
-                              *tmp = rel_TOK_equal;
+                              reloplist[row] = rel_TOK_equal;
                               break;
                case e_rel_greater:
                case e_rel_greatereq:
-                              *tmp = rel_TOK_greater;
+                              reloplist[row] = rel_TOK_greater;
                               break;
                default:
                               FPRINTF(stderr,"ERROR:  (slv6) calc_reloplist\n");
                               FPRINTF(stderr,"        Unknown relation type (not greater, less, or equal)\n");
+                              ascfree(reloplist);
                               return NULL;
            }
-       else
-           *tmp = rel_TOK_nonincident;
-
-       tmp++;  /* increment to new location in array */
+       else{
+           reloplist[row] = rel_TOK_nonincident;
+       }
 
    }
 
@@ -593,7 +654,7 @@ static char *calc_svtlist( struct var_variable **vlist,    /* input, not modifie
 	struct TypeDescription *solver_semi_type;
 
 	char *svtlist;  /* pointer for storage */
-	char *tmp;      /* temp pointer to set values */
+	int32 orgcol;
 
 	/* get the types for variable definitions */
 
@@ -638,44 +699,53 @@ static char *calc_svtlist( struct var_variable **vlist,    /* input, not modifie
 	*solver_semi_used = 0;
 	*solver_other_used = 0;
 	*solver_fixed = 0;
-	tmp = svtlist;
+	for(orgcol = 0; orgcol < vused; ++orgcol){
+		svtlist[orgcol] = MPS_FIXED;
+	}
 
 	/* loop over all vars */
 
 	for(; *vlist != NULL ; ++vlist )  {
+		orgcol = var_sindex(*vlist);
+		if((orgcol < 0) || (orgcol >= vused)){
+			FPRINTF(stderr,"ERROR:  (slv6) calc_svtlist\n");
+			FPRINTF(stderr,"        Variable index %d out of range.\n",(int)orgcol);
+			ascfree(svtlist);
+			return NULL;
+		}
 		if(free_inc_var_filter(*vlist) ){
 			type = InstanceTypeDesc(var_instance(*vlist));
 
 			if(type == MoreRefined(type,solver_binary_type) ){
 				if (var_relaxed(*vlist)){
-				   *tmp = MPS_RELAXED;
+				   svtlist[orgcol] = MPS_RELAXED;
 				   (*solver_relaxed_used)++;
 				}else{
-				   *tmp = MPS_BINARY;
+				   svtlist[orgcol] = MPS_BINARY;
 				   (*solver_binary_used)++;
 				}
 			}else{
 				if (type == MoreRefined(type,solver_int_type) ){
 					if(var_relaxed(*vlist)){
-						*tmp = MPS_RELAXED;
+						svtlist[orgcol] = MPS_RELAXED;
 						(*solver_relaxed_used)++;
 					}else{
-						*tmp = MPS_INT;
+						svtlist[orgcol] = MPS_INT;
 						(*solver_int_used)++;
 					}
 				}else{
 					if (type == MoreRefined(type,solver_semi_type) ){
 						if (var_relaxed(*vlist)){
-							*tmp = MPS_RELAXED;
+							svtlist[orgcol] = MPS_RELAXED;
 							(*solver_relaxed_used)++;
 						}else{
-							*tmp = MPS_SEMI;
+							svtlist[orgcol] = MPS_SEMI;
 							(*solver_semi_used)++;
 						}
 					}else{
 						if (type == MoreRefined(type,solver_var_type) ){
 							/* either solver var or some refinement */
-							*tmp = MPS_VAR;
+							svtlist[orgcol] = MPS_VAR;
 							(*solver_var_used)++;
 						}else{
 							FPRINTF(stderr,"ERROR:  (slv6) determine_svtlist\n");
@@ -686,10 +756,9 @@ static char *calc_svtlist( struct var_variable **vlist,    /* input, not modifie
 				}          /* if int */
 			}         /* if binary */
 		}else{
-			*tmp = MPS_FIXED;
+			svtlist[orgcol] = MPS_FIXED;
 			(*solver_fixed)++;
 		}
-		tmp++;
 	}
 	return svtlist;
 }
@@ -770,7 +839,8 @@ static mtx_matrix_t calc_matrix(int32     cap,
    var_filter_t vfilter;  /* checks for free incident vars in relman_diffs */
    double time0;          /* time of Jacobian calculation, among other things */
    struct rel_relation **rp;    /* relation pointer */
-   real64 *rhs;     /* temporary pointer for our RHS data */
+   int32 orgrow;
+   int status;
 
    if(obj == NULL) {         /* a little preflight checking */
       FPRINTF(stderr,"ERROR:  (slv6) calc_matrix\n");
@@ -794,13 +864,12 @@ static mtx_matrix_t calc_matrix(int32     cap,
    vfilter.in_block = var_ignore; */
 
    /* want to save column of residuals as they come along from relman_diffs */
-   *rhs_orig = create_array(rused,real64);
+   *rhs_orig = create_zero_array(rused,real64);
    if(*rhs_orig == NULL) {         /* memory allocation failed */
       FPRINTF(stderr,"ERROR:  (slv6) calc_matrix\n");
       FPRINTF(stderr,"        Memory allocation for right hand side failed!\n");
       return NULL;
    }
-   rhs = *rhs_orig;
 
 
   /* note: the rhs array is the residual at the current point, not what we want!
@@ -811,14 +880,21 @@ static mtx_matrix_t calc_matrix(int32     cap,
    for( rp = rlist ; *rp != NULL ; ++rp ) {
       /* fill out A matrix only for used elements */
       if( inc_rel_filter(*rp) ) {
-         *rhs = relman_diffs(*rp,&vfilter,mtx,rhs,safe);
-         /*calculate each row of A matrix here! */
-         rhs++;
-         if( ! calc_ok ) {   /* error check each call, calc_ok is in calc.h */
+         orgrow = rel_sindex(*rp);
+         if((orgrow < 0) || (orgrow >= rused)){
+            s->calc_ok = FALSE;  /* error in diffs ! */
+            FPRINTF(stderr,"ERROR:  (slv6) calc_matrix\n");
+            FPRINTF(stderr,"        Relation index %d out of range.\n",(int)orgrow);
+            destroy_array(*rhs_orig);  /* clean up house, then die */
+            mtx_destroy(mtx);                 /* zap all alocated memory */
+            return NULL;
+         }
+         status = relman_diffs(*rp,&vfilter,mtx,&((*rhs_orig)[orgrow]),safe);
+         if(status != 0) {
             s->calc_ok = FALSE;  /* error in diffs ! */
             FPRINTF(stderr,"ERROR:  (slv6) calc_matrix\n");
             FPRINTF(stderr,"        Error in calculating A matrix.\n");
-            destroy_array(rhs_orig);  /* clean up house, then die */
+            destroy_array(*rhs_orig);  /* clean up house, then die */
             mtx_destroy(mtx);                 /* zap all alocated memory */
             return NULL;
          }
@@ -830,7 +906,7 @@ static mtx_matrix_t calc_matrix(int32     cap,
       FPRINTF(stderr,"ERROR:  (slv6) calc_matrix\n");
       FPRINTF(stderr,"        Output assignment to calculate rank of problem failed.\n");
       mtx_destroy(mtx);                 /* zap all alocated memory */
-      destroy_array(rhs_orig);  /* clean up house, then die */
+      destroy_array(*rhs_orig);  /* clean up house, then die */
       return NULL;
    }
    *rank = mtx_symbolic_rank(mtx);
@@ -842,12 +918,12 @@ static mtx_matrix_t calc_matrix(int32     cap,
    }
 
    /* calculate the c vector and save it to the matrix */
-   if( ! calc_c(mtx, mtx_org_to_row(mtx,crow), obj) ) {
+   if( ! calc_c(mtx, crow, obj) ) {
       s->calc_ok = FALSE;  /* error in diffs ! */
       FPRINTF(stderr,"ERROR:  (slv6) calc_matrix\n");
       FPRINTF(stderr,"        Error in calculating objective coefficients.\n");
       mtx_destroy(mtx);    /* commit suicide */
-      destroy_array(rhs_orig);  /* clean up house, then die */
+      destroy_array(*rhs_orig);  /* clean up house, then die */
       return NULL;
    }
 
@@ -1239,6 +1315,16 @@ static SlvClientToken slv6_create(slv_system_t server, int32 *statusindex){   /*
 		return sys;
 	}
 
+	/* Bind this solver instance to the current system lists. */
+	sys->slv = server;
+	sys->vlist_user = slv_get_solvers_var_list(server);
+	sys->vlist = sys->vlist_user;
+	sys->blist_user = (struct bnd_boundary *)slv_get_solvers_bnd_list(server);
+	sys->blist = sys->blist_user;
+	sys->rlist_user = slv_get_solvers_rel_list(server);
+	sys->rlist = sys->rlist_user;
+	sys->obj = slv_get_obj_relation(server);
+
 	/***  Initialize system parameters ***/
 
 	sys->p.parms = sys->pa;
@@ -1403,17 +1489,12 @@ boolean slv6_eligible_solver(slv6_system_t server){
             slv_print_rel_name(MIF(sys),sys->slv, *rp);
             return(FALSE);   /* don't do nonlinearities */
           }
-#ifndef KILL
-      if (!exprman_is_linear(sys->obj,&vfilter)){
+      if(!relman_is_linear(sys->obj,&vfilter)){
           FPRINTF(MIF(sys), "ERROR:  With the current settings, the MPS generator can only\n");
-          FPRINTF(MIF(sys), "        handle linear models. Nonlinearity in objective.\n");
+          FPRINTF(MIF(sys), "        handle linear models. Nonlinearity in objective:\n");
+          slv_print_rel_name(MIF(sys),sys->slv, sys->obj);
           return(FALSE);   /* don't do nonlinearities */
       }
-#else
-     FPRINTF(stderr,"  function slv6_elegible_solver is slv6 is broken.\n");
-     FPRINTF(stderr," It calls exprman_is_linear with wrong number of args.\n");
-     exit(1);
-#endif
    }
 
    /*  Note: initially I had this routine check to see if solver could handle
@@ -1522,23 +1603,52 @@ void slv6_presolve(slv_system_t server){
    }
 
 #endif
-      /* compute info for variables */
-   sys->mps.vused = 0;     /* number starting at 0 */
-   sys->mps.vinc = 0;
-   for( vp = sys->vlist ; *vp != NULL ; vp++ ) {
-      if( free_inc_var_filter(*vp) )
-          sys->mps.vinc++;
-      sys->mps.vused++;    /* count up incident, non-fixed vars */
-   }
+	  /* Legacy incidence setup above is disabled; compute the core counts here. */
+	   sys->mps.rused = 0;
+	   sys->mps.rinc = 0;
+	   for( rp = sys->rlist ; *rp != NULL ; ++rp ) {
+	      if( inc_rel_filter(*rp) ) {
+	         sys->mps.rinc++;
+	      }
+	      sys->mps.rused++;
+	   }
 
-   /* calculate values for other index_mps_t vars */
-   sys->mps.crow     = sys->mps.rused;    /* note rused = N means rows 0 to N-1, exist,
-                                             the next one will be numbered rused */
-   /* calculate rank later */
+	      /* compute info for variables */
+	   sys->mps.vused = 0;     /* number starting at 0 */
+	   sys->mps.vinc = 0;
+	   for( vp = sys->vlist ; *vp != NULL ; vp++ ) {
+	      if( free_inc_var_filter(*vp) )
+	          sys->mps.vinc++;
+	      sys->mps.vused++;    /* count up incident, non-fixed vars */
+	   }
+	   if(sys->mps.vinc == 0){
+	      /* Fallback for systems where incident flags are not pre-marked. */
+	      var_filter_t active_free;
+	      active_free.matchbits = (VAR_FIXED | VAR_ACTIVE);
+	      active_free.matchvalue = VAR_ACTIVE;
+	      for( vp = sys->vlist ; *vp != NULL ; ++vp ) {
+	         if( var_apply_filter(*vp,&active_free) ){
+	            sys->mps.vinc++;
+	         }
+	      }
+	   }
 
-   /* Call slv6_elgibile_solver to see if the solver has a chance */
-   /* If not bail now ... requires the incidence values of prev section be set */
-   if(! slv6_eligible_solver(sys)) return;
+	   /* calculate values for other index_mps_t vars */
+	   sys->mps.cap = sys->mps.vused;
+	   if(sys->mps.cap < sys->mps.rused + 1){
+	      sys->mps.cap = sys->mps.rused + 1;
+	   }
+	   sys->mps.crow     = sys->mps.rused;    /* note rused = N means rows 0 to N-1, exist,
+	                                             the next one will be numbered rused */
+	   /* calculate rank later */
+
+	   /* Call slv6_elgibile_solver to see if the solver has a chance */
+	   /* If not bail now ... requires the incidence values of prev section be set */
+	   if(! slv6_eligible_solver(sys)) {
+	      FPRINTF(stderr,"ERROR:  (slv6) slv6_presolve\n");
+	      FPRINTF(stderr,"        Model is not eligible for MakeMPS export with current options.\n");
+	      return;
+	   }
 
    /*  Make sure that at least one incident variable and at least one incident
        relation exist, else bail */
@@ -1571,7 +1681,7 @@ void slv6_presolve(slv_system_t server){
    }
 
    /* get upper bound row */
-   sys->mps.ubrow = calc_bounds(sys->vlist, sys->mps.vinc, TRUE);
+   sys->mps.ubrow = calc_bounds(sys->vlist, sys->mps.vused, TRUE);
    if (sys->mps.ubrow == NULL)  {
       FPRINTF(stderr,"ERROR:  (slv6) slv6_presolve\n");
       FPRINTF(stderr,"        Error in calculating variable upper bounds.\n");
@@ -1580,7 +1690,7 @@ void slv6_presolve(slv_system_t server){
    }
 
    /* get lower bound row */
-   sys->mps.lbrow = calc_bounds(sys->vlist, sys->mps.vinc, FALSE);
+   sys->mps.lbrow = calc_bounds(sys->vlist, sys->mps.vused, FALSE);
    if (sys->mps.lbrow == NULL)  {
       FPRINTF(stderr,"ERROR:  (slv6) slv6_presolve\n");
       FPRINTF(stderr,"        Error in calculating variable lower bounds.\n");
@@ -1588,10 +1698,10 @@ void slv6_presolve(slv_system_t server){
       return;
    }
 
-   /* Call calc_svtlist to allocate array of variable types */
-   sys->mps.typerow = calc_svtlist(sys->vlist,
-                                   sys->mps.vinc,
-                                   &sys->mps.solver_var_used,      /* output */
+	/* Call calc_svtlist to allocate array of variable types */
+	sys->mps.typerow = calc_svtlist(sys->vlist,
+	                                sys->mps.vused,
+	                                &sys->mps.solver_var_used,      /* output */
                                    &sys->mps.solver_relaxed_used,  /* output */
                                    &sys->mps.solver_int_used,      /* output */
                                    &sys->mps.solver_binary_used,   /* output */
@@ -1606,7 +1716,7 @@ void slv6_presolve(slv_system_t server){
    }
 
    /* Call calc_reloplist here, to calculate the relational operators >=, <=, = */
-    sys->mps.relopcol = calc_reloplist(sys->rlist, sys->mps.rinc);
+	 sys->mps.relopcol = calc_reloplist(sys->rlist, sys->mps.rused);
     if(sys->mps.relopcol == NULL) {         /* allocation failed */
       FPRINTF(stderr,"ERROR:  (slv6) slv6_presolve\n");
       FPRINTF(stderr,"        Error in calculating the relational operators!\n");
@@ -1686,7 +1796,7 @@ void slv6_solve(slv_system_t server){
    /* Call write_mps to create the mps file */
    write_MPS(FN,     /* filename for output */
              sys->mps,                      /* main chunk of data */
-             sys->pa);
+             &(sys->p));
 
    /* replace .mps with .map at end of filename */
    *(FN+strlen(FN)-2) = 'a';
@@ -1744,7 +1854,61 @@ void slv6_resolve(slv_system_t server){
   */
 
    check_system(sys);
-   slv6_solve(server);
+	slv6_solve(server);
+}
+
+/* Adapters from modern solver API (server + token) to legacy slv6 callbacks. */
+static int makemps_destroy(slv_system_t server, SlvClientToken asys){
+	(void)server;
+	return slv6_destroy((slv_system_t)asys, asys);
+}
+
+static int makemps_eligible_solver(slv_system_t server){
+	SlvClientToken asys = slv_get_client_token(server);
+	if(asys == NULL){
+		return 0;
+	}
+	return slv6_eligible_solver((slv6_system_t)asys) ? 1 : 0;
+}
+
+static void makemps_get_parameters(slv_system_t server, SlvClientToken asys, slv_parameters_t *parameters){
+	(void)server;
+	slv6_get_parameters((slv_system_t)asys, parameters);
+}
+
+static void makemps_set_parameters(slv_system_t server, SlvClientToken asys, slv_parameters_t *parameters){
+	(void)server;
+	slv6_set_parameters((slv_system_t)asys, parameters);
+}
+
+static int makemps_get_status(slv_system_t server, SlvClientToken asys, slv_status_t *status){
+	(void)server;
+	slv6_get_status((slv_system_t)asys, status);
+	return 0;
+}
+
+static int makemps_solve(slv_system_t server, SlvClientToken asys){
+	(void)server;
+	slv6_solve((slv_system_t)asys);
+	return 0;
+}
+
+static int makemps_presolve(slv_system_t server, SlvClientToken asys){
+	(void)server;
+	slv6_presolve((slv_system_t)asys);
+	return 0;
+}
+
+static int makemps_iterate(slv_system_t server, SlvClientToken asys){
+	(void)server;
+	slv6_iterate((slv_system_t)asys);
+	return 0;
+}
+
+static int makemps_resolve(slv_system_t server, SlvClientToken asys){
+	(void)server;
+	slv6_resolve((slv_system_t)asys);
+	return 0;
 }
 
 
@@ -1752,16 +1916,16 @@ static const SlvFunctionsT makemps_internals = {
 	6
 	,"MakeMPS"
 	,slv6_create
-  	,slv6_destroy
-	,slv6_eligible_solver
+  	,makemps_destroy
+	,makemps_eligible_solver
 	,slv6_get_default_parameters
-	,slv6_get_parameters
-	,slv6_set_parameters
-	,slv6_get_status
-	,slv6_solve
-	,slv6_presolve
-	,slv6_iterate
-	,slv6_resolve
+	,makemps_get_parameters
+	,makemps_set_parameters
+	,makemps_get_status
+	,makemps_solve
+	,makemps_presolve
+	,makemps_iterate
+	,makemps_resolve
 	,NULL
 	,NULL
 	,NULL
@@ -1771,4 +1935,3 @@ static const SlvFunctionsT makemps_internals = {
 int makemps_register(void){
 	return solver_register(&makemps_internals);
 }
-

--- a/solvers/makemps/slv6.c
+++ b/solvers/makemps/slv6.c
@@ -280,8 +280,7 @@ static int check_system(slv6_system_t sys)
  **/
 {
    if( sys == NULL ) {
-      FPRINTF(stderr,"ERROR:  (slv6) check_system\n");
-      FPRINTF(stderr,"        NULL system handle.\n");
+      ERROR_REPORTER_HERE(ASC_PROG_ERR,"NULL system handle.");
       return 1;
    }
 
@@ -289,12 +288,10 @@ static int check_system(slv6_system_t sys)
    case OK:
       return 0;
    case DESTROYED:
-      FPRINTF(stderr,"ERROR:  (slv6) check_system\n");
-      FPRINTF(stderr,"        System was recently destroyed.\n");
+      ERROR_REPORTER_HERE(ASC_PROG_ERR,"System was recently destroyed.");
       return 1;
    default:
-      FPRINTF(stderr,"ERROR:  (slv6) check_system\n");
-      FPRINTF(stderr,"        System reused or never allocated.\n");
+      ERROR_REPORTER_HERE(ASC_PROG_ERR,"System reused or never allocated.");
       return 1;
    }
 }
@@ -374,8 +371,7 @@ static FILE *get_output_file(FILE *fp){
    if( fp==NULL ) {
       if(nuldev==NULL)
 	 if( (nuldev=fopen(fname,"w")) == NULL ) {
-	    FPRINTF(stderr,"ERROR:  (slv6) get_output_file\n");
-	    FPRINTF(stderr,"        Unable to open %s.\n",fname);
+	    ERROR_REPORTER_HERE(ASC_PROG_ERR,"Unable to open %s.",fname);
 	 }
       fp=nuldev;
    }
@@ -465,8 +461,7 @@ static boolean calc_c(mtx_matrix_t mtx,     /* matrix to store derivs */
       int safe = 0;
 
       if ((mtx == NULL) || (obj == NULL)) {         /* got a bad pointer */
-          FPRINTF(stderr,"ERROR:  (slv6) calc_c\n");
-          FPRINTF(stderr,"        Routine was passed a NULL pointer!\n");
+          ERROR_REPORTER_HERE(ASC_PROG_ERR,"Routine was passed a NULL pointer!");
           return FALSE;
       }
 
@@ -478,8 +473,7 @@ static boolean calc_c(mtx_matrix_t mtx,     /* matrix to store derivs */
 
       row = mtx_org_to_row(mtx,org_row);       /* convert from original numbering to current */
       if(row < 0){
-          FPRINTF(stderr,"ERROR:  (slv6) calc_c\n");
-          FPRINTF(stderr,"        Invalid objective row index %d.\n", (int)org_row);
+          ERROR_REPORTER_HERE(ASC_PROG_ERR,"Invalid objective row index %d.", (int)org_row);
           return FALSE;
       }
 
@@ -491,8 +485,7 @@ static boolean calc_c(mtx_matrix_t mtx,     /* matrix to store derivs */
       derivs = ASC_NEW_ARRAY_OR_NULL(real64,len);
       vars = ASC_NEW_ARRAY_OR_NULL(int32,len);
       if((derivs == NULL) || (vars == NULL)){
-          FPRINTF(stderr,"ERROR:  (slv6) calc_c\n");
-          FPRINTF(stderr,"        Memory allocation failed.\n");
+          ERROR_REPORTER_HERE(ASC_PROG_ERR,"Memory allocation failed.");
           if(derivs)ascfree(derivs);
           if(vars)ascfree(vars);
           return FALSE;
@@ -501,8 +494,7 @@ static boolean calc_c(mtx_matrix_t mtx,     /* matrix to store derivs */
       count = 0;
       status = relman_diff2(obj,&vfilter,derivs,vars,&count,safe);
       if(status != 0){
-          FPRINTF(stderr,"ERROR:  (slv6) calc_c\n");
-          FPRINTF(stderr,"        Failed to evaluate objective gradient.\n");
+          ERROR_REPORTER_HERE(ASC_PROG_ERR,"Failed to evaluate objective gradient.");
           ascfree(derivs);
           ascfree(vars);
           return FALSE;
@@ -511,8 +503,7 @@ static boolean calc_c(mtx_matrix_t mtx,     /* matrix to store derivs */
       coord.row = org_row;
       for(i = 0; i < count; ++i){
           if(vars[i] < 0 || vars[i] >= mtx_order(mtx)){
-              FPRINTF(stderr,"ERROR:  (slv6) calc_c\n");
-              FPRINTF(stderr,"        Objective column index %d out of range.\n", (int)vars[i]);
+              ERROR_REPORTER_HERE(ASC_PROG_ERR,"Objective column index %d out of range.", (int)vars[i]);
               ascfree(derivs);
               ascfree(vars);
               return FALSE;
@@ -540,23 +531,20 @@ static real64 *calc_bounds(struct var_variable **vlist, /* variable list to get 
       int32 col;
 
       if (vlist == NULL) {         /* got a bad pointer */
-          FPRINTF(stderr,"ERROR:  (slv6) calc_bounds\n");
-          FPRINTF(stderr,"        Routine was passed a NULL variable list pointer!\n");
+          ERROR_REPORTER_HERE(ASC_PROG_ERR,"Routine was passed a NULL variable list pointer.");
           return FALSE;
       }
 
       tmp_array_origin = create_zero_array(vused,real64);
       if (tmp_array_origin == NULL) {
-          FPRINTF(stderr,"ERROR:  (slv6) calc_bounds\n");
-          FPRINTF(stderr,"        Memory allocation failed!\n");
+          ERROR_REPORTER_HERE(ASC_PROG_ERR,"Memory allocation failed.");
           return FALSE;
       }
 
       for( ; *vlist != NULL ; ++vlist ){
          col = var_sindex(*vlist);
          if((col < 0) || (col >= vused)){
-            FPRINTF(stderr,"ERROR:  (slv6) calc_bounds\n");
-            FPRINTF(stderr,"        Variable index %d out of range.\n",(int)col);
+            ERROR_REPORTER_HERE(ASC_PROG_ERR,"Variable index %d out of range.",(int)col);
             ascfree(tmp_array_origin);
             return FALSE;
          }
@@ -588,8 +576,7 @@ static char *calc_reloplist(struct rel_relation **rlist,
 
    reloplist = create_zero_array(rused,char);  /* default is rel_TOK_nonincident */
    if (reloplist == NULL) {         /* memory allocation failed */
-          FPRINTF(stderr,"ERROR:  (slv6) calc_reloplist\n");
-          FPRINTF(stderr,"        Memory allocation failed!\n");
+          ERROR_REPORTER_HERE(ASC_PROG_ERR,"Memory allocation failed!");
           return NULL;
    }
 
@@ -597,8 +584,7 @@ static char *calc_reloplist(struct rel_relation **rlist,
    {
        row = rel_sindex(*rlist);
        if((row < 0) || (row >= rused)){
-           FPRINTF(stderr,"ERROR:  (slv6) calc_reloplist\n");
-           FPRINTF(stderr,"        Relation index %d out of range.\n",(int)row);
+           ERROR_REPORTER_HERE(ASC_PROG_ERR,"Relation index %d out of range.",(int)row);
            ascfree(reloplist);
            return NULL;
        }
@@ -617,8 +603,7 @@ static char *calc_reloplist(struct rel_relation **rlist,
                               reloplist[row] = rel_TOK_greater;
                               break;
                default:
-                              FPRINTF(stderr,"ERROR:  (slv6) calc_reloplist\n");
-                              FPRINTF(stderr,"        Unknown relation type (not greater, less, or equal)\n");
+                              ERROR_REPORTER_HERE(ASC_PROG_ERR,"Unknown relation type (not greater, less, or equal)");
                               ascfree(reloplist);
                               return NULL;
            }
@@ -660,27 +645,19 @@ static char *calc_svtlist( struct var_variable **vlist,    /* input, not modifie
 	/* get the types for variable definitions */
 
 	if( (solver_var_type = FindType(AddSymbol(MPS_VAR_STR))) == NULL ) {
-		FPRINTF(stderr,"ERROR:  (slv6.c) get_solver_var_type\n");
-		FPRINTF(stderr,"        Type solver_var not defined.\n");
-		FPRINTF(stderr,"        MPS will not work.\n");
+		ERROR_REPORTER_HERE(ASC_PROG_ERR,"Type '%s' not defined; MPS export will not work.", MPS_VAR_STR);
 		return NULL;
 	}
 	if( (solver_int_type = FindType(AddSymbol(MPS_INT_STR))) == NULL ) {
-		FPRINTF(stderr,"ERROR:  (slv6.c) get_solver_var_type\n");
-		FPRINTF(stderr,"        Type solver_int not defined.\n");
-		FPRINTF(stderr,"        MPS will not work.\n");
+		ERROR_REPORTER_HERE(ASC_PROG_ERR,"Type '%s' not defined; MPS export will not work.", MPS_INT_STR);
 		return NULL;
 	}
 	if( (solver_binary_type = FindType(AddSymbol(MPS_BINARY_STR))) == NULL ) {
-		FPRINTF(stderr,"ERROR:  (slv6.c) get_solver_var_type\n");
-		FPRINTF(stderr,"        Type solver_binary not defined.\n");
-		FPRINTF(stderr,"        MPS will not work.\n");
+		ERROR_REPORTER_HERE(ASC_PROG_ERR,"Type '%s' not defined; MPS export will not work.", MPS_BINARY_STR);
 		return NULL;
 	}
 	if( (solver_semi_type = FindType(AddSymbol(MPS_SEMI_STR))) == NULL ) {
-		FPRINTF(stderr,"ERROR:  (slv6.c) get_solver_var_type\n");
-		FPRINTF(stderr,"        Type solver_semi not defined.\n");
-		FPRINTF(stderr,"        MPS will not work.\n");
+		ERROR_REPORTER_HERE(ASC_PROG_ERR,"Type '%s' not defined; MPS export will not work.", MPS_SEMI_STR);
 		return NULL;
 	}
 
@@ -688,8 +665,7 @@ static char *calc_svtlist( struct var_variable **vlist,    /* input, not modifie
 
 	svtlist = create_array(vused,char);  /* see macro */
 	if (svtlist == NULL) {         /* memory allocation failed */
-		  FPRINTF(stderr,"ERROR:  (slv6) calc_svtlist\n");
-		  FPRINTF(stderr,"        Memory allocation failed for solver var type list!\n");
+		  ERROR_REPORTER_HERE(ASC_PROG_ERR,"Memory allocation failed for solver var type list!");
 		  return NULL;
 	}
 
@@ -709,8 +685,7 @@ static char *calc_svtlist( struct var_variable **vlist,    /* input, not modifie
 	for(; *vlist != NULL ; ++vlist )  {
 		orgcol = var_sindex(*vlist);
 		if((orgcol < 0) || (orgcol >= vused)){
-			FPRINTF(stderr,"ERROR:  (slv6) calc_svtlist\n");
-			FPRINTF(stderr,"        Variable index %d out of range.\n",(int)orgcol);
+			ERROR_REPORTER_HERE(ASC_PROG_ERR,"Variable index %d out of range.",(int)orgcol);
 			ascfree(svtlist);
 			return NULL;
 		}
@@ -749,8 +724,7 @@ static char *calc_svtlist( struct var_variable **vlist,    /* input, not modifie
 							svtlist[orgcol] = MPS_VAR;
 							(*solver_var_used)++;
 						}else{
-							FPRINTF(stderr,"ERROR:  (slv6) determine_svtlist\n");
-							FPRINTF(stderr,"        Unknown solver_var type encountered.\n");
+							ERROR_REPORTER_HERE(ASC_PROG_ERR,"Unknown solver_var type encountered.");
 							/* should never get to here */
 						}
 					}          /* if semi */
@@ -844,8 +818,7 @@ static mtx_matrix_t calc_matrix(int32     cap,
    int status;
 
    if(obj == NULL) {         /* a little preflight checking */
-      FPRINTF(stderr,"ERROR:  (slv6) calc_matrix\n");
-      FPRINTF(stderr,"        System must have an objective!\n");
+      ERROR_REPORTER_HERE(ASC_PROG_ERR,"System must have an objective!");
       return NULL;
    }
 
@@ -867,8 +840,7 @@ static mtx_matrix_t calc_matrix(int32     cap,
    /* want to save column of residuals as they come along from relman_diffs */
    *rhs_orig = create_zero_array(rused,real64);
    if(*rhs_orig == NULL) {         /* memory allocation failed */
-      FPRINTF(stderr,"ERROR:  (slv6) calc_matrix\n");
-      FPRINTF(stderr,"        Memory allocation for right hand side failed!\n");
+      ERROR_REPORTER_HERE(ASC_PROG_ERR,"Memory allocation for right hand side failed!");
       return NULL;
    }
 
@@ -884,8 +856,7 @@ static mtx_matrix_t calc_matrix(int32     cap,
          orgrow = rel_sindex(*rp);
          if((orgrow < 0) || (orgrow >= rused)){
             s->calc_ok = FALSE;  /* error in diffs ! */
-            FPRINTF(stderr,"ERROR:  (slv6) calc_matrix\n");
-            FPRINTF(stderr,"        Relation index %d out of range.\n",(int)orgrow);
+            ERROR_REPORTER_HERE(ASC_PROG_ERR,"Relation index %d out of range.",(int)orgrow);
             destroy_array(*rhs_orig);  /* clean up house, then die */
             mtx_destroy(mtx);                 /* zap all alocated memory */
             return NULL;
@@ -893,8 +864,7 @@ static mtx_matrix_t calc_matrix(int32     cap,
          status = relman_diffs(*rp,&vfilter,mtx,&((*rhs_orig)[orgrow]),safe);
          if(status != 0) {
             s->calc_ok = FALSE;  /* error in diffs ! */
-            FPRINTF(stderr,"ERROR:  (slv6) calc_matrix\n");
-            FPRINTF(stderr,"        Error in calculating A matrix.\n");
+            ERROR_REPORTER_HERE(ASC_PROG_ERR,"Error in calculating A matrix.");
             destroy_array(*rhs_orig);  /* clean up house, then die */
             mtx_destroy(mtx);                 /* zap all alocated memory */
             return NULL;
@@ -904,8 +874,7 @@ static mtx_matrix_t calc_matrix(int32     cap,
    /* Calculate the rank of the matrix, before we add extra rows/cols */
    mtx_output_assign(mtx, crow, vused);
    if(! mtx_output_assigned(mtx)) {  /* output assignment failed */
-      FPRINTF(stderr,"ERROR:  (slv6) calc_matrix\n");
-      FPRINTF(stderr,"        Output assignment to calculate rank of problem failed.\n");
+      ERROR_REPORTER_HERE(ASC_PROG_ERR,"Output assignment to calculate rank of problem failed.");
       mtx_destroy(mtx);                 /* zap all alocated memory */
       destroy_array(*rhs_orig);  /* clean up house, then die */
       return NULL;
@@ -913,16 +882,14 @@ static mtx_matrix_t calc_matrix(int32     cap,
    *rank = mtx_symbolic_rank(mtx);
 
    if( *rank < 0 ) {
-      FPRINTF(stderr,"ERROR:  (slv6) calc_matrix\n");
-      FPRINTF(stderr,"        Symbolic rank calculation failed, matrix may be bad.\n");
+      ERROR_REPORTER_HERE(ASC_PROG_ERR,"Symbolic rank calculation failed, matrix may be bad.");
       return mtx;
    }
 
    /* calculate the c vector and save it to the matrix */
    if( ! calc_c(mtx, crow, obj) ) {
       s->calc_ok = FALSE;  /* error in diffs ! */
-      FPRINTF(stderr,"ERROR:  (slv6) calc_matrix\n");
-      FPRINTF(stderr,"        Error in calculating objective coefficients.\n");
+      ERROR_REPORTER_HERE(ASC_PROG_ERR,"Error in calculating objective coefficients.");
       mtx_destroy(mtx);    /* commit suicide */
       destroy_array(*rhs_orig);  /* clean up house, then die */
       return NULL;
@@ -966,8 +933,7 @@ static void real_rhs(mtx_matrix_t    Ac_mtx,      /* Matrix representation of pr
    double       rowval;   /* the sum of a[i]*x[i] in the row */
 
    if(rhs == NULL) {         /* a little preflight checking */
-      FPRINTF(stderr,"ERROR:  (slv6) real_rhs\n");
-      FPRINTF(stderr,"        The routine was passed a NULL rhs pointer!\n");
+      ERROR_REPORTER_HERE(ASC_PROG_ERR,"The routine was passed a NULL rhs pointer!");
       return;
    }
 
@@ -1245,8 +1211,7 @@ struct rel_relation *slv6_get_obj_relation(slv6_system_t sys){
 void slv6_dump_internals(slv6_system_t sys, int level){
    check_system(sys);
    if (level > 0) {
-      FPRINTF(stderr,"ERROR:  (slv6) slv6_dump_internals\n");
-      FPRINTF(stderr,"        slv6 does not dump its internals.\n");
+      ERROR_REPORTER_HERE(ASC_PROG_ERR,"Dumping internals is not implemented.");
    }
 }
 #endif
@@ -1286,8 +1251,7 @@ boolean slv6_change_basis(slv6_system_t sys,int32 var, mtx_range_t *rng){
    Nor, for that matter, is there a basis in the first place.
    So I just write out an error message, and return FALSE  */
 
-   FPRINTF(stderr,"ERROR:  (slv6) slv6_change_basis\n");
-   FPRINTF(stderr,"        This solver does not support changing the basis.\n");
+   ERROR_REPORTER_HERE(ASC_PROG_ERR,"Changing basis is not supported.");
 
    return FALSE;
 }
@@ -1467,13 +1431,11 @@ boolean slv6_eligible_solver(slv6_system_t server){
 
    check_system(sys);
    if( sys->rlist == NULL ) {
-      FPRINTF(stderr,"ERROR:  (slv6) slv6_eligible_solver\n");
-      FPRINTF(stderr,"        Relation list was never set.\n");
+      ERROR_REPORTER_HERE(ASC_PROG_ERR,"Relation list was never set.");
       return (FALSE);
    }
    if( sys->obj == NULL ) {
-      FPRINTF(stderr,"ERROR:  (slv6) slv6_eligible_solver\n");
-      FPRINTF(stderr,"        No objective in problem.\n");
+      ERROR_REPORTER_HERE(ASC_PROG_ERR,"No objective in problem.");
       return (FALSE);
    }
 
@@ -1536,18 +1498,15 @@ void slv6_presolve(slv_system_t server){
    /* Check if necessary pointers are non-NULL */
    check_system(sys);
    if( sys->vlist == NULL ) {
-      FPRINTF(stderr,"ERROR:  (slv6) slv6_presolve\n");
-      FPRINTF(stderr,"        Variable list was never set.\n");
+      ERROR_REPORTER_HERE(ASC_PROG_ERR,"Variable list was never set.");
       return;
    }
    if( sys->blist == NULL ) {
-      FPRINTF(stderr,"ERROR:  (slv6) slv6_presolve\n");
-      FPRINTF(stderr,"        Boundary list was never set.\n");
+      ERROR_REPORTER_HERE(ASC_PROG_ERR,"Boundary list was never set.");
       return;
    }
    if( sys->rlist == NULL ) {
-      FPRINTF(stderr,"ERROR:  (slv6) slv6_presolve\n");
-      FPRINTF(stderr,"        Relation list was never set.\n");
+      ERROR_REPORTER_HERE(ASC_PROG_ERR,"Relation list was never set.");
       return;
    }
 
@@ -1562,7 +1521,7 @@ void slv6_presolve(slv_system_t server){
    if( sys->vlist_user == NULL ) determine_vlist(sys);
 #else
    if( sys->vlist_user == NULL ){
-     FPRINTF(stderr,"  function determine_vlist is slv6 is broken.\n");
+     ERROR_REPORTER_HERE(ASC_PROG_ERR,"automatic variable-list setup is broken.");
      exit(1);
    }
 #endif
@@ -1658,18 +1617,17 @@ void slv6_presolve(slv_system_t server){
 	   /* Call slv6_elgibile_solver to see if the solver has a chance */
 	   /* If not bail now ... requires the incidence values of prev section be set */
 	   if(! slv6_eligible_solver(sys)) {
-	      FPRINTF(stderr,"ERROR:  (slv6) slv6_presolve\n");
-	      FPRINTF(stderr,"        Model is not eligible for MakeMPS export with current options.\n");
+	      ERROR_REPORTER_HERE(ASC_PROG_ERR,"Model is not eligible for MakeMPS export with current options.");
 	      return;
 	   }
 
    /*  Make sure that at least one incident variable and at least one incident
        relation exist, else bail */
    if ((sys->mps.rinc == 0) || (sys->mps.vinc == 0))  {
-      FPRINTF(stderr,"ERROR:  (slv6) slv6_presolve\n");
-      FPRINTF(stderr,"        Your model must have at least one incident variable and equation.\n");
-      FPRINTF(stderr,"        Incident variables: %d\n", sys->mps.vinc);
-      FPRINTF(stderr,"        Incident equations: %d\n", sys->mps.rinc);
+      ERROR_REPORTER_HERE(ASC_PROG_ERR
+         ,"Your model must have at least one incident variable and equation (incident variables: %d, incident equations: %d)."
+         ,sys->mps.vinc, sys->mps.rinc
+      );
       return;
    }
 
@@ -1687,8 +1645,7 @@ void slv6_presolve(slv_system_t server){
                                  &sys->mps.rank,
                                  &sys->mps.bcol);
    if( sys->mps.Ac_mtx == NULL ) {
-      FPRINTF(stderr,"ERROR:  (slv6) slv6_presolve\n");
-      FPRINTF(stderr,"        Call to calc_matrix failed.\n");
+      ERROR_REPORTER_HERE(ASC_PROG_ERR,"failed to build matrix representation.");
       nuke_pointers(sys->mps);
       return;
    }
@@ -1696,8 +1653,7 @@ void slv6_presolve(slv_system_t server){
    /* get upper bound row */
    sys->mps.ubrow = calc_bounds(sys->vlist, sys->mps.vused, TRUE);
    if (sys->mps.ubrow == NULL)  {
-      FPRINTF(stderr,"ERROR:  (slv6) slv6_presolve\n");
-      FPRINTF(stderr,"        Error in calculating variable upper bounds.\n");
+      ERROR_REPORTER_HERE(ASC_PROG_ERR,"Error in calculating variable upper bounds.");
       nuke_pointers(sys->mps);
       return;
    }
@@ -1705,8 +1661,7 @@ void slv6_presolve(slv_system_t server){
    /* get lower bound row */
    sys->mps.lbrow = calc_bounds(sys->vlist, sys->mps.vused, FALSE);
    if (sys->mps.lbrow == NULL)  {
-      FPRINTF(stderr,"ERROR:  (slv6) slv6_presolve\n");
-      FPRINTF(stderr,"        Error in calculating variable lower bounds.\n");
+      ERROR_REPORTER_HERE(ASC_PROG_ERR,"Error in calculating variable lower bounds.");
       nuke_pointers(sys->mps);
       return;
    }
@@ -1722,8 +1677,7 @@ void slv6_presolve(slv_system_t server){
                                    &sys->mps.solver_other_used,    /* output */
                                    &sys->mps.solver_fixed);        /* output */
    if(sys->mps.typerow == NULL) {         /* allocation failed */
-      FPRINTF(stderr,"ERROR:  (slv6) slv6_presolve\n");
-      FPRINTF(stderr,"        Error in calculating the variable type list!\n");
+      ERROR_REPORTER_HERE(ASC_PROG_ERR,"Error in calculating the variable type list!");
       nuke_pointers(sys->mps);
       return;
    }
@@ -1731,8 +1685,7 @@ void slv6_presolve(slv_system_t server){
    /* Call calc_reloplist here, to calculate the relational operators >=, <=, = */
 	 sys->mps.relopcol = calc_reloplist(sys->rlist, sys->mps.rused);
     if(sys->mps.relopcol == NULL) {         /* allocation failed */
-      FPRINTF(stderr,"ERROR:  (slv6) slv6_presolve\n");
-      FPRINTF(stderr,"        Error in calculating the relational operators!\n");
+      ERROR_REPORTER_HERE(ASC_PROG_ERR,"Error in calculating the relational operators!");
       nuke_pointers(sys->mps);
       return;
    }
@@ -1784,16 +1737,16 @@ void slv6_solve(slv_system_t server){
        (sys->mps.bcol == NULL) ||
        (sys->mps.typerow == NULL) ||
        (sys->mps.relopcol == NULL)) {
-      FPRINTF(MIF(sys),"ERROR:  Matrix representation of problem is not available.\n");
-      FPRINTF(MIF(sys),"        Perhaps the presolve routine was not called before slv6_solve.\n");
+      ERROR_REPORTER_HERE(ASC_PROG_ERR
+         ,"Matrix representation of problem is not available; presolve may not have been called."
+      );
       return;
    }
 
    /* Check system to see if it can be solved  */
    check_system(sys);
    if( !sys->s.ready_to_solve ) {
-      FPRINTF(stderr,"ERROR:  (slv6) slv6_solve\n");
-      FPRINTF(stderr,"        Not ready to solve.\n");
+      ERROR_REPORTER_HERE(ASC_PROG_ERR,"Not ready to solve.");
       return;
    }
 

--- a/solvers/makemps/slv6.c
+++ b/solvers/makemps/slv6.c
@@ -937,6 +937,7 @@ static void real_rhs(mtx_matrix_t    Ac_mtx,      /* Matrix representation of pr
                      char            relopcol[],  /* is it incident? */
                      struct var_variable  **vlist,      /* Variable list (NULL terminated) */
                      int32     rused,       /* in: total number of relations used */
+                     int32     vused,       /* in: total number of variables used */
                      real64    rhs[])       /* out: rhs array origin */
 /**
  ***  Takes the residuals stored in rhs, and converts them into the actual right
@@ -977,11 +978,11 @@ static void real_rhs(mtx_matrix_t    Ac_mtx,      /* Matrix representation of pr
 	   nz.row = currow;       /* current row */
            rowval = 0.0;          /* accumulate value here */
 
-           a = mtx_next_in_row(Ac_mtx,&nz,mtx_range(&range,0,rused));
+           a = mtx_next_in_row(Ac_mtx,&nz,mtx_range(&range,0,vused));
 
            do  {  orgcol  = mtx_col_to_org(Ac_mtx, nz.col);
                   rowval += a*var_value(*(vlist+orgcol));
-                  a = mtx_next_in_row(Ac_mtx,&nz,mtx_range(&range,0,rused));
+                  a = mtx_next_in_row(Ac_mtx,&nz,mtx_range(&range,0,vused));
 
                } while (nz.col != mtx_LAST);
 
@@ -1729,6 +1730,7 @@ void slv6_presolve(slv_system_t server){
             sys->mps.relopcol,    /* is it incident? */
             sys->vlist,           /* in: Variable list (NULL terminated) */
             sys->mps.rused,       /* in: total number of relations used */
+            sys->mps.vused,       /* in: total number of variables used */
             sys->mps.bcol);       /* out: rhs array origin */
 
 

--- a/solvers/makemps/slv6.h
+++ b/solvers/makemps/slv6.h
@@ -54,8 +54,8 @@
  *                parameter: the system.  Note also that the select
  *                solver functions don't exist.
  *  </pre>
- *  @todo makeMPS (solver/slv6.c) is out-of-date and will not compile.
- *        Should be either fixed or archived.
+ *  @todo makeMPS (solver/slv6.c) remains legacy code and needs refactoring.
+ *        It currently compiles and is covered by solver tests.
  *  @todo Restructure solver/slv6 & mps so can remove declarations in
  *        solver/slv6.h out of header.  Currently needed by mps.[ch].
  */
@@ -242,4 +242,3 @@ enum{
 #define rel_TOK_nonincident 00
 
 #endif  /* ASC_SLV6_H */
-

--- a/test/mallocdebug.tests
+++ b/test/mallocdebug.tests
@@ -7,6 +7,7 @@ solver_slvreq
 solver_lrslv
 solver_ipopt
 solver_makemps
+solver_highs
 
 linear_mtx
 

--- a/test/mallocdebug.tests
+++ b/test/mallocdebug.tests
@@ -6,6 +6,7 @@ solver_slv_common
 solver_slvreq
 solver_lrslv
 solver_ipopt
+solver_makemps
 
 linear_mtx
 


### PR DESCRIPTION
MakeMPS now works as an export tool for LPs again, with strict nonlinear gating by default and opt-in linearization.

  What Changed

  - Re-enabled real MPS writing and switched it to current parameter API (slv_parameters_t) in solvers/makemps/mps.c:806 and solvers/makemps/mps.h:59.
  - Kept full ASCEND path mapping in .map output (already via WriteInstanceName) in solvers/makemps/mps.c:312.
  - Fixed objective coefficient build (calc_c) to use relation-level derivatives (relman_diff2) instead of dead exprman_diffs in solvers/makemps/slv6.c:453.
  - Fixed stale API mismatch where relman_diffs status was being written into RHS; now status and residual are handled correctly in solvers/makemps/slv6.c:892.
  - Fixed indexing/allocation bugs in presolve data setup:
      - variable bounds/type vectors now sized/indexed on vused (solvers/makemps/slv6.c:1684, solvers/makemps/slv6.c:1702)
      - relation-op vector now sized on rused (solvers/makemps/slv6.c:1719)
  - Fixed the parameter registration bug where "eps" was stored in SP6_BO instead of SP6_EPS at solvers/makemps/slv6.c:215.
  - Restored relman_is_linear as a real function (Hessian-based check over filtered vars) in ascend/system/relman.h:47 and ascend/system/relman.c:111.
  - Hardened timestamp formatting to remove fortify overflow abort in solvers/makemps/mps.c:90.

  Tests Added/Updated

  - Existing MakeMPS LP tests now run in strict linear mode (nonlin=FALSE) in ascend/solver/test/test_makemps.c:122.
  - Added nonlinear rejection test (default strict mode) in ascend/solver/test/test_makemps.c:185.
  - Added nonlinear linearization test (nonlin=TRUE) in ascend/solver/test/test_makemps.c:263.

  Validation Run

  - ./a4 cutest solver_makemps -v
  - Result: 4/4 tests passed (makemps_lp1, makemps_lp_structured, makemps_rejects_nonlinear_default, makemps_linearises_nonlinear_when_enabled).
