### PR TITLE
add tests for parameterized model merge behaviour

### DIFF
--- a/ascend/compiler/test/test_merge_parameterized.c
+++ b/ascend/compiler/test/test_merge_parameterized.c
@@ -1,0 +1,116 @@
+#include <string.h>
+
+#include <ascend/general/env.h>
+#include <ascend/utilities/ascEnvVar.h>
+#include <ascend/utilities/error.h>
+
+#include <ascend/compiler/ascCompiler.h>
+#include <ascend/compiler/module.h>
+#include <ascend/compiler/parser.h>
+#include <ascend/compiler/library.h>
+#include <ascend/compiler/symtab.h>
+#include <ascend/compiler/simlist.h>
+#include <ascend/compiler/instquery.h>
+#include <ascend/compiler/parentchild.h>
+
+#include <test/common.h>
+#include <test/assertimpl.h>
+
+static struct Instance *instantiate_parameterized_merge_case(
+		const char *modelname, int expect_error){
+	struct module_t *m;
+	struct Instance *sim;
+	int status;
+	int has_error;
+
+	Asc_CompilerInit(1);
+	Asc_PutEnv(ASC_ENV_LIBRARY "=models");
+
+	m = Asc_OpenModule("test/merge/merge_parameterized.a4c", &status);
+	(void)m;
+	CU_ASSERT(status == 0);
+	CU_ASSERT(zz_parse() == 0);
+	CU_ASSERT(FindType(AddSymbol(modelname)) != NULL);
+
+	error_reporter_tree_start();
+	sim = SimsCreateInstance(AddSymbol(modelname), AddSymbol("sim1"),
+			e_normal, NULL);
+	has_error = error_reporter_tree_has_error();
+	error_reporter_tree_end();
+
+	if(expect_error){
+		CU_ASSERT(has_error || sim == NULL);
+	}else{
+		CU_ASSERT(sim != NULL);
+		CU_ASSERT(!has_error);
+	}
+	return sim;
+}
+
+static void test_merge_param_fail_same_argument(void){
+	struct Instance *sim = instantiate_parameterized_merge_case(
+			"merge_param_fail_same_argument", 1);
+	if(sim){
+		sim_destroy(sim);
+	}
+	Asc_CompilerDestroy();
+}
+
+static void test_merge_param_fail_equal_distinct_arguments(void){
+	struct Instance *sim = instantiate_parameterized_merge_case(
+			"merge_param_fail_equal_distinct_arguments", 1);
+	if(sim){
+		sim_destroy(sim);
+	}
+	Asc_CompilerDestroy();
+}
+
+static void test_merge_param_ok_merge_base_then_refine(void){
+	struct Instance *sim = instantiate_parameterized_merge_case(
+			"merge_param_ok_merge_base_then_refine", 0);
+	struct Instance *root = GetSimulationRoot(sim);
+	struct Instance *u1 = ChildByChar(root, AddSymbol("U1"));
+	struct Instance *u2 = ChildByChar(root, AddSymbol("U2"));
+	struct Instance *outlet = ChildByChar(u1, AddSymbol("outlet"));
+	struct Instance *inlet = ChildByChar(u2, AddSymbol("inlet"));
+
+	CU_ASSERT(root != NULL);
+	CU_ASSERT(u1 != NULL);
+	CU_ASSERT(u2 != NULL);
+	CU_ASSERT(outlet != NULL);
+	CU_ASSERT(inlet != NULL);
+	CU_ASSERT(outlet == inlet);
+	CU_ASSERT(ChildByChar(outlet, AddSymbol("f")) != NULL);
+
+	sim_destroy(sim);
+	Asc_CompilerDestroy();
+}
+
+static void test_merge_param_ok_shared_stream_parameter(void){
+	struct Instance *sim = instantiate_parameterized_merge_case(
+			"merge_param_ok_shared_stream_parameter", 0);
+	struct Instance *root = GetSimulationRoot(sim);
+	struct Instance *s1 = ChildByChar(root, AddSymbol("S1"));
+	struct Instance *u1 = ChildByChar(root, AddSymbol("U1"));
+	struct Instance *u2 = ChildByChar(root, AddSymbol("U2"));
+	struct Instance *u1_outlet = ChildByChar(u1, AddSymbol("outlet"));
+	struct Instance *u2_inlet = ChildByChar(u2, AddSymbol("inlet"));
+
+	CU_ASSERT(root != NULL);
+	CU_ASSERT(s1 != NULL);
+	CU_ASSERT(u1 != NULL);
+	CU_ASSERT(u2 != NULL);
+	CU_ASSERT(u1_outlet == s1);
+	CU_ASSERT(u2_inlet == s1);
+
+	sim_destroy(sim);
+	Asc_CompilerDestroy();
+}
+
+#define TESTS(T) \
+	T(merge_param_fail_same_argument) \
+	T(merge_param_fail_equal_distinct_arguments) \
+	T(merge_param_ok_merge_base_then_refine) \
+	T(merge_param_ok_shared_stream_parameter)
+
+REGISTER_TESTS_SIMPLE(compiler_merge_parameterized, TESTS)

--- a/ascend/compiler/test/test_register_compiler.c
+++ b/ascend/compiler/test/test_register_compiler.c
@@ -64,7 +64,8 @@
 	T(merge_arrays) \
 	T(merge_dims) \
 	T(merge_model_children) \
-	T(merge_model_values)
+	T(merge_model_values) \
+	T(merge_parameterized)
 
 
 #define PROTO_TEST(NAME) PROTO(compiler,NAME)

--- a/models/test/merge/merge_parameterized.a4c
+++ b/models/test/merge/merge_parameterized.a4c
@@ -1,0 +1,86 @@
+(*
+	ARE_THE_SAME and parameterised stream/port patterns.
+
+	The compiler currently rejects merging two instances of a parameterised
+	MODEL, even when both instances use the same actual parameter object.  Two
+	supported connection patterns are tested alongside that restriction:
+
+	1. merge unparameterised base ports first, then refine the resulting shared
+	   instance to a parameterised stream type;
+	2. instantiate the parameterised stream once at flowsheet level and pass
+	   that same stream instance as a WILL_BE parameter to adjacent units.
+*)
+
+MODEL merge_param_package;
+	components IS_A set OF symbol_constant;
+END merge_param_package;
+
+MODEL merge_param_port_base;
+	T IS_A real;
+END merge_param_port_base;
+
+MODEL merge_param_stream(
+	pkg WILL_BE merge_param_package;
+) REFINES merge_param_port_base;
+	components ALIASES pkg.components;
+	f[components] IS_A real;
+END merge_param_stream;
+
+MODEL merge_param_internal_port_unit(
+	pkg WILL_BE merge_param_package;
+);
+	inlet IS_A merge_param_stream(pkg);
+	outlet IS_A merge_param_stream(pkg);
+END merge_param_internal_port_unit;
+
+MODEL merge_param_base_port_unit;
+	inlet IS_A merge_param_port_base;
+	outlet IS_A merge_param_port_base;
+END merge_param_base_port_unit;
+
+MODEL merge_param_shared_stream_unit(
+	inlet WILL_BE merge_param_stream;
+	outlet WILL_BE merge_param_stream;
+) WHERE (
+	inlet.pkg, outlet.pkg WILL_BE_THE_SAME;
+);
+END merge_param_shared_stream_unit;
+
+(* Current compiler restriction: the parameter object is exactly the same. *)
+MODEL merge_param_fail_same_argument;
+	pkg IS_A merge_param_package;
+	pkg.components :== ['a', 'b'];
+	U1, U2 IS_A merge_param_internal_port_unit(pkg);
+	U1.outlet, U2.inlet ARE_THE_SAME;
+END merge_param_fail_same_argument;
+
+(* Current compiler restriction also applies to equal-valued but distinct
+   parameter objects. *)
+MODEL merge_param_fail_equal_distinct_arguments;
+	pkg1, pkg2 IS_A merge_param_package;
+	pkg1.components :== ['a', 'b'];
+	pkg2.components :== ['a', 'b'];
+	U1 IS_A merge_param_internal_port_unit(pkg1);
+	U2 IS_A merge_param_internal_port_unit(pkg2);
+	U1.outlet, U2.inlet ARE_THE_SAME;
+END merge_param_fail_equal_distinct_arguments;
+
+(* Supported pattern: merge the unparameterised base instances before
+   refining the one resulting shared instance. *)
+MODEL merge_param_ok_merge_base_then_refine;
+	pkg IS_A merge_param_package;
+	pkg.components :== ['a', 'b'];
+	U1, U2 IS_A merge_param_base_port_unit;
+	U1.outlet, U2.inlet ARE_THE_SAME;
+	U1.outlet IS_REFINED_TO merge_param_stream(pkg);
+END merge_param_ok_merge_base_then_refine;
+
+(* Supported thermodynamics.a4l-style pattern: S1 is the connection because
+   the same previously instantiated stream is passed to both units. *)
+MODEL merge_param_ok_shared_stream_parameter;
+	pkg IS_A merge_param_package;
+	pkg.components :== ['a', 'b'];
+	S0, S1, S2 IS_A merge_param_stream(pkg);
+	U1 IS_A merge_param_shared_stream_unit(S0, S1);
+	U2 IS_A merge_param_shared_stream_unit(S1, S2);
+END merge_param_ok_shared_stream_parameter;


### PR DESCRIPTION
  Cover the current ARE_THE_SAME restriction for parameterized model
  instances, including identical and equal-valued arguments. Test the
  supported base-port refinement and shared WILL_BE stream patterns.